### PR TITLE
fix(skill-cron): $HOME instead of hardcoded /Users path

### DIFF
--- a/skill-cron/scripts/run_banini.sh
+++ b/skill-cron/scripts/run_banini.sh
@@ -15,4 +15,4 @@ fi
 
 PROMPT='Run python3 ~/.claude/skills/banini/scripts/scrape_threads.py banini31 5, parse the JSON output, then perform 反指標 contrarian analysis on the posts following these rules: 買入=可能跌, 停損=可能反彈, 被套=續跌, 看多=可能跌, 看空=可能漲, 買put=可能飆漲. Output a structured report in Traditional Chinese with 提及標的, 連鎖推導, 建議方向, and 冥燈指數. End with 僅供娛樂參考，不構成投資建議.'
 
-exec /Users/otakubear/.claude/skills/skill-cron/scripts/cron_runner.sh "$PROMPT" "$JOB_ID"
+exec "$HOME/.claude/skills/skill-cron/scripts/cron_runner.sh" "$PROMPT" "$JOB_ID"


### PR DESCRIPTION
run_banini.sh 的 exec 路徑寫死 /Users/<username>/，改用 $HOME — 既不洩本機 username 又通用。