### PR TITLE
loop-engineer v0.1.0 — unattended evaluator-optimizer dispatch authoring + traffic-light notify

### DIFF
--- a/loop-engineer/SKILL.md
+++ b/loop-engineer/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: loop-engineer
+description: "Use when the user wants to set up an UNATTENDED, goal-driven evaluator-optimizer loop (generate → grade → iterate by reason-code) that a fresh-session agent runs hands-off while the human only watches push notifications. Interactively locks the spec via forcing questions, then emits a self-contained dispatch markdown + a channel-agnostic traffic-light notification protocol. NOT a time scheduler (that is /loop or cron) and NOT a recurring-push registrar (that is skill-cron) — this authors the one-shot unattended-loop spec a fresh session can run blind."
+version: 0.1.0
+triggers: ["/loop-engineer", "loop engineering", "loop engineer", "設計無人值守loop", "固化loop", "unattended loop", "evaluator-optimizer loop", "dispatch 換手文件"]
+---
+
+# /loop-engineer — Unattended Loop Dispatch Architect
+
+You are a **loop-engineering architect**. You turn a vague "I want an agent to grind on X by itself" into a **self-contained dispatch markdown** that a *fresh-session* agent can execute hands-off — generating, grading its own output, and iterating by reason-code — while the human only monitors traffic-light (🟢🟡🔴) push notifications and makes the taste calls at gates.
+
+This skill **produces a spec + a notification protocol. It does NOT run the loop itself.**
+
+## What this is / isn't（先讀，避免叫錯工具）
+
+| | `loop-engineer`（本 skill） | 不是這個 |
+|---|---|---|
+| 模式 | **goal-driven** evaluator-optimizer（生成→評→依原因碼迭代）| time-driven 週期重跑（`/loop`、cron）|
+| 產出 | 一份 dispatch markdown + 通知協定 | 註冊定時推播（`skill-cron`）|
+| 誰來跑 | **新 session 的無人值守 agent**（長跑的 agent runner session）| 當前 session |
+| 人的角色 | 看 🟢🟡🔴、在 gate 挑/拍板 | 全程盯著 |
+
+## 執行規則
+
+1. 跟 user 互動用 user 的語言；產出的 dispatch 文件：section 標題可雙語、內文用 user 語言。
+2. **Forcing questions 一次問一塊**，每塊推到具體答案才往下（不要一次丟 7 題、會拿到淺答案）。
+3. **不替 user 腦補**。不知道就問——整個重點是「規格精確到能 blind hand-off」。
+4. dispatch 文件輸出到 user 指定路徑（預設 `docs/<task>_dispatch.md`）。
+
+## Stage Detection（自動判斷）
+
+1. user 指名既有 dispatch 文件 / 說「resume」→ 載入它、跳到沒填完的洞。
+2. user 描述新的無人值守 loop 需求 → 跑 Forcing Questions。
+3. 只打 `/loop-engineer` → 問「你想讓 loop 自己磨什麼?」
+
+## Forcing Questions（鎖規格 — 一塊一塊問）
+
+**Q1 — 目標 + 工作項**
+loop 要**產出 / 優化什麼**?它迭代的**離散工作項**是什麼?
+- 推到：一個可衡量的交付物 + 一個可列舉的清單/矩陣（N 項 × M 變體）。
+- 🚩 紅旗：「就弄好一點」→ 釘出可量測的目標。
+
+**Q2 — 約束 / 紅線**
+agent **絕對不能做**什麼?scope 邊界、禁止動作、只有人能決定的事。
+- 推到：一串 ❌ bullet（**逐條原樣進 dispatch 文件**）。
+- **必含一條**：「不准自己拍板最終選定（final selection）/ 不自己做品味判斷 — 人才是 ground truth。」
+
+**Q3 — 驗收 gate**
+每個產出怎麼判?**兩層閘**是驗證有效的形狀：
+- **扣分閘（floor）**：硬缺陷自動退（輸出損壞 / build 壞 / lint fail / schema 不合 …）。
+- **達標閘（ceiling）**：真的**命中目標**了嗎（不是「沒缺陷」就算過）?
+- 誰評?（獨立 skeptic subagent / 客觀指標 / 測試套件）。有沒有**客觀指標**能兜底?
+- 推到：一個帶**原因碼**的 rubric（讓迭代是針對性的、不是亂猜）。
+
+**Q4 — 停止條件**
+- per-item：湊滿 ≥K 過閘，或迭代 ≤N 輪，或 **loop-until-dry**（連 M 輪沒新東西）。
+- **3 出口**：`NEEDS_INPUT`（缺料）/ `ESCALATE`（連 2 輪沒進步、通知人）/ `REFUSE`（越紅線）。
+- **防空轉**：第 2 輪起每輪必報 delta（跟上輪差在哪）；講不出有意義 delta → 停。
+
+**Q5 — runner + 環境**
+- 哪個 model/agent 無人值守跑、跑在哪（長跑的無人值守 agent session / CI job）?
+- resume：要不要把 state 落磁碟、被 kill 能續?
+- 🚩 **別假設某個 model 一定在**（model 會被下架；保持可替換）。
+
+**Q6 — 可重現**
+🔴 鐵律：**「只有結果、沒配方 = 白跑」**。每個候選必須帶什麼?
+- 推到：sidecar/recipe 規格（參數/種子/輸入/版本）+ run log（每輪參數 + 判定 + 原因碼 + delta）。
+
+**Q7 — 通知通道**（channel-agnostic、這塊最常踩坑）
+- **哪個通道?** Telegram（預設）/ Discord / iMessage / Slack / 其他 — user 自由指定。
+- **credential 哪來?** user 可：(a) 直接給 chat_id/token、(b) 指一個 config 檔路徑（helper `NOTIFY_CONFIG`）、(c) 指定一個安全 config 來源讓你取。🔴 **dispatch 只記「來源是哪個 env var / config」、永不寫 secret 本身**。把「creds 從哪來」問到具體。
+- **觸發時機**：pre-flight 測通（**通知測得通才准開跑**）/ per-milestone（**不是 per-item、避免洗版**）/ 事故已處理 / 收工總結 / 選用心跳 pulse。
+- **格式**：紅綠燈 🟢🟡🔴（見 `references/notify-protocol.md`）。
+
+## 產出 dispatch 文件
+
+用 Q1–Q7 的答案填 `references/dispatch-template.md` → 寫到指定路徑。然後**自審**：
+- 每段都具體、無「TBD / 看情況」（模糊 = 不能 hand-off）。
+- 約束逐條原樣在；停止條件含 3 出口 + delta；可重現鐵律在；通知通道+creds+觸發都釘死；pre-flight gate 在最前。
+- 回報一份 **handoff checklist**（讓 user 一眼知道怎麼接、不用追問）：
+  - 📄 dispatch 路徑：`<path>`
+  - 🔑 需要的 credential env var（依 channel）：`<列出名稱>` — secret 由 user 自己注入、不在文件裡
+  - ✅ pre-flight 指令：`<跑通知測通的指令>`
+  - ▶️ 開跑指令：`<丟給無人值守 session 的指令>`
+  - 👀 之後 user 只顧 🟢🟡🔴、在 gate 挑最終選定。
+
+## Anti-patterns
+
+- ❌ 一次丟 7 題（拿到淺答案）。
+- ❌ dispatch 文件留「TBD / 看情況」（= 不能 blind hand-off 的廢規格）。
+- ❌ 讓 runner 自己拍板最終選定 / 自做品味判斷。
+- ❌ per-item 通知（洗版）→ 改 per-milestone。
+- ❌ 寫死某 model（保持可替換）。
+- ❌ 「只有結果沒配方」→ 每候選都帶重現 recipe。
+- ❌ 沒 pre-flight 通知測通就開跑（通知靜默失敗 = 盲跑）。
+- ❌ 寫死 Telegram（通道是 Q7 的決定、抽象化 transport）。
+
+## Important rules（context 再長也要記住）
+
+1. **goal-driven、不是 time-driven**。user 要「每 10 分鐘」那是 `/loop`/cron、不是本 skill。
+2. dispatch 文件要能被**新 session blind 跑**——零隱含 context。
+3. **兩層閘**（floor + ceiling）：「沒缺陷」≠「命中目標」。
+4. **3 出口 + delta 防空轉**是必備停止條件。
+5. **人 = 品味/最終選定的 ground truth**；loop 只產候選 + review bundle，不自己拍板。
+6. **可重現是紅線**：每產出帶 recipe sidecar + run log。
+7. **通知 channel-agnostic + pre-flight 測通**；格式紅綠燈 🟢🟡🔴。
+8. loop 規模對齊 user 的 ask；有任何 silent cap（top-N / 不重試 / 抽樣）要**明講**、別藏。
+
+## References（用本 skill 時必讀 dispatch-template + notify-protocol；用 shell helper 才讀/複製 notify.sh）
+
+- `references/dispatch-template.md` — 本 skill 要吐的 dispatch markdown 骨架。
+- `references/notify-protocol.md` — 紅綠燈協定 + channel-agnostic 通知設計 + helper 用法。
+- `references/notify.sh` — 參考用 sidecar 通知 helper（Telegram 預設、Discord/iMessage hook）。

--- a/loop-engineer/references/dispatch-template.md
+++ b/loop-engineer/references/dispatch-template.md
@@ -1,0 +1,91 @@
+# `<task>` Dispatch — `<one-line goal>`
+
+> Self-contained hand-off spec for an **unattended evaluator-optimizer loop**. A fresh-session agent runs this **blind**; the human only watches 🟢🟡🔴 notifications and picks at gates. Fill every `<...>`; leave **no `TBD`** (a vague field = an un-runnable spec).
+> 🔴 This file may be committed — **never write secrets into it** (tokens/ids/URLs/handles), and prefer relative paths; if an absolute path is unavoidable, keep this dispatch private / redact before sharing.
+
+## 0. Goal & scope
+- **Goal:** `<measurable target — what "done/good" means>`
+- **Scope this run:** `<exactly which items; what is explicitly out>`
+
+## 1. Architecture / runner
+- **Runner:** `<model/agent, kept swappable — do not hardcode a model that may be deprecated>`
+- **Where:** `<unattended host/session, e.g. a long-running agent session or a CI job>`
+- **Dispatched how:** `<command/entry the human runs to kick it off>`
+- **Resume:** `<persist state to disk so a killed run continues? where (e.g. state.json)?>`
+
+## 2. Inputs (ready / to-prepare)
+- ✅ `<asset/data already in place — relative path preferred>`
+- ⏳ `<asset still to prepare, and by whom>`
+
+## 3. Work items (matrix)
+`<the enumerable list the loop iterates over — N items × M variants>`
+
+| item | variant A | variant B |
+|---|---|---|
+| `<item1>` | ✔ | ✔ |
+
+## 4. Constraints / hard lines（逐條 verbatim 進 runner prompt）
+- 🔴 `<forbidden action / scope guard>`
+- 🔴 **Do not self-approve the final selection / do not make subjective approval calls — the human is ground truth.** Produce candidates + a review bundle, hand off.
+- 🔴 `<reproducibility / safety / privacy red line>`
+
+## 5. Evaluation / gates（怎麼判每個 candidate）
+- **Floor gate（扣分閘，硬缺陷自動退）：** `<auto-reject defects — invalid/broken output, fails a hard check>`
+- **Ceiling gate（達標閘，真的命中目標嗎）：** `<positive criterion that means it HITS the goal — not just "no defect">`
+- **Grader：** `<who/what judges — an independent skeptic subagent (default-refute) / a test suite / an objective metric>`；能量化就加客觀指標兜底。
+- **Reason-codes（讓迭代針對性、不亂猜）：**
+
+| code | 意思 | 預設動作 |
+|---|---|---|
+| `<R1>` | `<what failed>` | `<how to adjust next round>` |
+| `<R2>` | ... | ... |
+
+## 6. Stop conditions
+- **per-item:** hit **≥K** passing, OR iterate **≤N** rounds, OR **loop-until-dry** (M consecutive rounds with nothing new) — first to fire wins.
+- **3 exits:** `NEEDS_INPUT` (missing material) / `ESCALATE` (no progress 2 rounds → notify human) / `REFUSE` (crosses a red line).
+- **anti-spin:** from round 2, every round states a **delta** vs last; no meaningful delta → stop.
+
+## 7. Reproducibility（鐵律：只有結果、沒配方 = 白跑）
+- 🔴 every candidate carries a **`.recipe` sidecar** (`<params/inputs/versions/...>`).
+- 🔴 a **run log** per round: params + verdict + reason-code + delta.
+- a milestone notification carries enough handle (`<item id / batch / round>`) for the human to map a pick back to its recipe.
+
+## 8. Notification（triggers/format SSOT = `notify-protocol.md`）
+- **Channel:** `<telegram / discord / slack / imessage / other>`
+- **Credential source:** `<which env vars (e.g. TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID); where the secret lives — a private config / NOTIFY_CONFIG path. The secret itself is NOT written here.>`
+- **Triggers + format:** per `notify-protocol.md` (pre-flight test · per-milestone 🟢 · 🟡 incident-handled · 🔴 blocked · finish summary). Do not redefine here — reference it.
+
+## 9. Pre-flight gate（fail-fast，最前面跑）
+0. **Notification test passes** (send a test ping; `notify.sh` returns non-zero on failure → do not start the loop).
+1. `<runtime/service ready check>`
+2. `<inputs present + required tools available (curl / python3 / ...)>`
+3. `<smoke 1 item end-to-end before the full matrix>`
+
+## 10. Execution procedure（per-item loop — 新 session 照這個跑）
+1. Load state (resume if `<state file>` exists, else fresh) + read this dispatch.
+2. For each work item × variant:
+   a. **Generate** a candidate (write a *draft* `.recipe` now — a crash still leaves a reproducible artifact).
+   b. **Floor gate** → fail: log reason-code, apply the code's default action, retry (respect ≤N).
+   c. **Ceiling gate** → fail: log reason-code, adjust, retry.
+   d. **Pass** → finalize the `.recipe` + append run log.
+   e. Check **stop conditions** (≥K / ≤N / dry / delta); hit an exit → handle (`NEEDS_INPUT`/`ESCALATE`/`REFUSE`).
+3. On milestone (a batch/phase done) → 🟢 notify (+ review bundle if media).
+4. On finish → assemble review bundle, 🟢 summary notify, hand candidates to the human.
+5. 🔴 Never self-select the final selection — that's the human's call.
+
+## 11. Fallback
+- `<if approach A fails (e.g. the primary producer refuses / a gate never passes), what is plan B>`
+
+---
+
+## Worked example (abstract — replace with your task)
+
+> **`bug-hunt` Dispatch — find & verify real bugs in module `<X>`, 0 false positives**
+> - **Goal:** ≥5 confirmed, reproducible bugs, each with a failing test.
+> - **Runner:** a general agent on a long-running unattended session; resumes from `state.json`.
+> - **Work items:** files in `<X>/` × {correctness, edge-case, concurrency} lenses.
+> - **Constraints:** 🔴 don't "fix" anything — report only. 🔴 don't self-mark a bug "real" — an independent skeptic verifies. 🔴 human triages the final list.
+> - **Evaluation:** floor = reproduces on current HEAD; ceiling = a *minimal failing test* exists. Grader = independent skeptic subagent, default-refute. Reason-codes: `NOREPRO`→drop, `FLAKY`→stabilize, `KNOWN`→dedup.
+> - **Stop:** ≥5 confirmed OR 8 rounds OR 2 dry rounds.
+> - **Reproducibility:** each finding → `.recipe` (file:line, repro steps, test snippet) + round log.
+> - **Notification:** telegram (creds from `NOTIFY_CONFIG`); 🟢 per finding-batch, 🔴 ESCALATE if 2 dry rounds.

--- a/loop-engineer/references/notify-protocol.md
+++ b/loop-engineer/references/notify-protocol.md
@@ -1,0 +1,63 @@
+# Notification protocol — traffic-light, channel-agnostic
+
+The loop reports to the human over a **push channel**. The *format* (traffic-light) is channel-independent; only the *transport* differs. Decide the channel + credential source in the skill's Q7, then wire `notify.sh` (or your own helper) accordingly.
+
+> **Artifact-neutral by default.** The protocol assumes outputs are generic candidates (text, code, structured data, files). If your loop produces **media** (images/audio/video), see the *Media artifacts (optional)* note at the bottom — that part is opt-in, not core.
+
+## Traffic-light format（每則開頭帶燈號）
+
+| 燈 | 意思 | 何時 | 內容 |
+|---|---|---|---|
+| 🟢 | 進度（看一眼、不用動） | milestone 完成 N 個 candidate / phase 開始 | 一兩句：剛做完什麼 + 接下來。結尾固定「續跑中、不用動」。 |
+| 🟡 | 注意（不阻塞、loop 續跑） | 重試 / 自癒已處理 / 有 workaround | 發生什麼 + 怎麼繞 + 是否要事後關注。 |
+| 🔴 | 需要你（阻塞、要人介入） | `NEEDS_INPUT` / `ESCALATE` / `REFUSE` / gate 連續紅 | 開頭 `🔴 需要你：<具體動作>` + 帶具體欄位（卡哪、需要什麼決定、暫停範圍）。`ESCALATE` 必帶 delta。 |
+
+## Triggers（什麼事件發 — milestone 粒度、不是 per-candidate）
+
+- **Pre-flight 測通（第 0 步、硬擋）**：開跑前送一則測試 ping；**送不出去（helper 回非零）就不准開 loop**（通知靜默失敗 = 盲跑）。可要人回任意字確認雙向通。
+- **per-milestone**：每完成**一個 phase / 一批 candidates / 一個工作項的所有變體**一則 🟢。🔴 **不要 per-candidate**（洗版）。把「milestone」定義成「一批、不是一個」。
+- **事故已處理**：自癒後一則 🟡（不 stop-and-ask）。
+- **收工 / 階段總結**：完成清單 + 各項通過數 + 阻塞 + 待人挑。
+- **（選）心跳 pulse**：長靜默每 N 分鐘一則，防無人值守久跑讓人不安 / 補 silent-death（見 watchdog）。
+
+## Channel-agnostic transport
+
+| Channel | Transport | Credential（由 Q7 決定來源、env/config 注入）|
+|---|---|---|
+| Telegram | `sendMessage` / `sendPhoto` HTTP API（curl）| `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` |
+| Discord | incoming webhook（curl POST）| `DISCORD_WEBHOOK_URL` |
+| Slack | incoming webhook（curl POST、text-only）| `SLACK_WEBHOOK_URL` |
+| iMessage | local `osascript`（macOS only）| `IMESSAGE_TO` |
+| other | 自訂 | — |
+
+**Credential source（Q7 決定，三種常見）**：
+- (a) operator 互動時直接給 → 寫進該專案的私有 env / config（**不進 repo、不寫進 dispatch 文件正文**）。
+- (b) operator 指一個 **config 檔路徑** → helper `NOTIFY_CONFIG=<path>` source 它。
+- (c) operator 指定一個**安全的 config 來源**讓你取 → 取用即可。
+- 🔴 **token / chat_id / webhook URL / handle 一律由 env 或 config 注入，永不寫進 skill、永不進 repo、永不寫進 dispatch 文件**（dispatch 只記「來源是哪個 env var / 哪個 config」，不記 secret 本身；dispatch 若會進 repo，路徑也要 redact）。
+
+## Watchdog（選用、補無人值守 silent-death）
+
+無人值守 job 會**靜默失敗、沒人知道**——常見模式：deadlock 卡死、`exit 0` 但輸出全空、執行環境中途中斷。若在意，在一個**常駐的、獨立於 loop 的**輕量 session 掛心跳：每 N 分鐘檢查「loop 還活著嗎」（輸出有沒有增長 / log 有沒有更新 / state 時間戳），偵測到停滯就發 🔴。**關鍵：watchdog 要獨立**（loop 自己死了就發不出自己的告警）。
+
+## `notify.sh` 用法
+
+```bash
+NOTIFY_CHANNEL=telegram NOTIFY_CONFIG=/path/to/private-notify.env \
+  notify.sh 🟢 "phase-1 done, 4/5 candidates passing, 續跑中不用動"
+notify.sh 🔴 "需要你：input 缺，NEEDS_INPUT — 暫停 item-5"
+```
+
+- `NOTIFY_CHANNEL`（telegram|discord|slack|imessage）+ 對應 credential 由執行環境或 `NOTIFY_CONFIG` 注入。
+- helper **送失敗回非零** → pre-flight gate 才真的擋得住。
+- ⚠️ `NOTIFY_CONFIG` 是被 **source 的 shell 檔（會執行內容）** → 只指向你自己掌控的私有檔。
+- ⚠️ webhook 類的 token / URL 會出現在 **process argv**（同機其他程序可能看到）→ 跑在信任的 host。
+- 需 `curl`；webhook JSON escape 需 `python3`；圖壓縮需 `magick`/`convert`（pre-flight 一併檢查）。
+
+## Media artifacts (optional — only if your outputs are media)
+
+若 loop 產出是圖/影音（非預設）：milestone 通知可附一張**彙整圖（review bundle）**讓人快速初篩。注意：
+- 🔴 媒體檔路徑要在**執行發送的那台機器**本機絕對路徑（遠端跑就先放那台 / 傳過去）。
+- 大檔先壓（`notify.sh` 對 PNG/webp 自動壓 JPEG；需 magick/convert，否則送原檔），避免上傳 timeout。
+- caption 帶 milestone handle（item id / 批次 / 輪數）讓人挑完對得回 recipe。
+- Slack / iMessage（本 helper）只發文字、會略過媒體並在 stderr 警告。

--- a/loop-engineer/references/notify.sh
+++ b/loop-engineer/references/notify.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# notify.sh — channel-agnostic traffic-light notifier for unattended loops.
+# Reference helper for the loop-engineer skill. Copy into your project, wire the
+# channel + credentials per your dispatch doc. NOT meant to run from the skill repo.
+#
+# Usage:
+#   notify.sh <emoji> <text> [local-media-path]
+#   notify.sh 🟢 "item-3 done, 4 passing, still running"
+#   notify.sh 🟢 "milestone done" /abs/path/review-bundle.png   # image auto-compressed to JPEG
+#   notify.sh 🔴 "need you: input missing, NEEDS_INPUT"
+#
+# Channel:  NOTIFY_CHANNEL = telegram | discord | slack | imessage   (default telegram)
+# Optional: NOTIFY_CONFIG = /path/to/private.env  → sourced before sending (TRUSTED shell file you own)
+#
+# 🔴 Credentials come ONLY from env (or NOTIFY_CONFIG you source) — NEVER hardcode
+#    tokens/ids/URLs/handles, NEVER commit them, NEVER write them into a dispatch doc.
+#      telegram : TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+#      discord  : DISCORD_WEBHOOK_URL
+#      slack    : SLACK_WEBHOOK_URL
+#      imessage : IMESSAGE_TO   (macOS only; sends locally via osascript)
+#
+# Requirements: curl. (discord/slack JSON escaping needs python3. image compress needs magick/convert.)
+# Exit code: non-zero if the send fails — so a pre-flight test can actually gate on it.
+set -uo pipefail
+
+EMOJI="${1:?usage: notify.sh <emoji> <text> [media]}"
+TEXT="${2:?missing text}"
+MEDIA="${3:-}"
+MSG="${EMOJI} ${TEXT}"
+CH="${NOTIFY_CHANNEL:-telegram}"
+
+# optional: load secrets from a config file the operator points at (kept private, never committed)
+if [ -n "${NOTIFY_CONFIG:-}" ]; then
+  [ -f "$NOTIFY_CONFIG" ] || { echo "[notify] NOTIFY_CONFIG not found: $NOTIFY_CONFIG" >&2; exit 1; }
+  set -a; # shellcheck disable=SC1090
+  source "$NOTIFY_CONFIG"; set +a
+fi
+
+die(){ echo "[notify] $*" >&2; exit 1; }
+TMP=""   # cleaned on exit
+cleanup(){ [ -n "$TMP" ] && rm -f "$TMP"; }
+trap cleanup EXIT
+
+# JSON-encode a string safely (for webhook payloads). Falls back to error if no python3.
+json_str(){ command -v python3 >/dev/null 2>&1 || die "discord/slack need python3 for JSON escaping"; printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'; }
+
+# compress big images to a unique temp JPEG (avoid upload timeouts); only if media given + is image
+prep_media(){
+  [ -n "$MEDIA" ] && [ -f "$MEDIA" ] || { MEDIA=""; return; }
+  case "$MEDIA" in
+    *.png|*.PNG|*.webp|*.WEBP)
+      local conv=""
+      if command -v magick >/dev/null 2>&1; then conv=magick; elif command -v convert >/dev/null 2>&1; then conv=convert; fi
+      [ -n "$conv" ] || { echo "[notify] no image converter (magick/convert); sending original (may be large)" >&2; return; }
+      TMP="$(mktemp "${TMPDIR:-/tmp}/notify.XXXXXX.jpg")"
+      if "$conv" "$MEDIA" -quality 90 "$TMP" 2>/dev/null; then MEDIA="$TMP"; else echo "[notify] image compress failed; sending original" >&2; fi ;;
+  esac
+}
+
+# wrapper: curl that actually fails loud
+post(){ curl --fail --show-error --silent --max-time 25 "$@"; }
+
+case "$CH" in
+  telegram)
+    : "${TELEGRAM_BOT_TOKEN:?set TELEGRAM_BOT_TOKEN}"; : "${TELEGRAM_CHAT_ID:?set TELEGRAM_CHAT_ID}"
+    api="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}"
+    prep_media
+    if [ -n "$MEDIA" ]; then
+      post -F chat_id="$TELEGRAM_CHAT_ID" -F caption="$MSG" -F photo="@${MEDIA}" "$api/sendPhoto" >/dev/null || die "telegram send failed"
+    else
+      post "$api/sendMessage" -d chat_id="$TELEGRAM_CHAT_ID" --data-urlencode text="$MSG" >/dev/null || die "telegram send failed"
+    fi ;;
+  discord)
+    : "${DISCORD_WEBHOOK_URL:?set DISCORD_WEBHOOK_URL}"; prep_media
+    if [ -n "$MEDIA" ]; then
+      post -F "content=$MSG" -F "file1=@${MEDIA}" "$DISCORD_WEBHOOK_URL" >/dev/null || die "discord send failed"
+    else
+      post -H "Content-Type: application/json" -d "{\"content\":$(json_str "$MSG")}" "$DISCORD_WEBHOOK_URL" >/dev/null || die "discord send failed"
+    fi ;;
+  slack)
+    : "${SLACK_WEBHOOK_URL:?set SLACK_WEBHOOK_URL}"
+    [ -n "$MEDIA" ] && echo "[notify] slack incoming-webhook can't upload media; sending text only" >&2
+    post -H "Content-Type: application/json" -d "{\"text\":$(json_str "$MSG")}" "$SLACK_WEBHOOK_URL" >/dev/null || die "slack send failed" ;;
+  imessage)
+    : "${IMESSAGE_TO:?set IMESSAGE_TO}"; command -v osascript >/dev/null 2>&1 || die "imessage needs macOS osascript"
+    [ -n "$MEDIA" ] && echo "[notify] imessage path sends text only here; media skipped" >&2
+    # pass strings as argv (osascript 'on run') to avoid AppleScript injection / quoting breakage
+    osascript - "$IMESSAGE_TO" "$MSG" <<'APPLESCRIPT' >/dev/null || die "imessage send failed"
+on run argv
+  tell application "Messages" to send (item 2 of argv) to buddy (item 1 of argv)
+end run
+APPLESCRIPT
+    ;;
+  *) die "unknown NOTIFY_CHANNEL=$CH (telegram|discord|slack|imessage)" ;;
+esac
+echo "[notify] sent via $CH"


### PR DESCRIPTION
互動式問 forcing questions 鎖規格 → 吐一份新 session 可 blind 執行的 dispatch markdown + channel-agnostic 紅綠燈通知協定。跟 /loop(時間排程)、skill-cron(定時推播)區隔。

- SKILL.md：role + stage detection + 7 forcing questions（目標/約束/驗收gate/停止條件/runner/可重現/通知通道）+ anti-patterns + important rules + handoff checklist。
- references/dispatch-template.md：通用換手骨架（含 Evaluation/rubric/reason-code + per-item execution）。
- references/notify-protocol.md：🟢🟡🔴 協定 + channel-agnostic（telegram/discord/slack/imessage）+ watchdog。
- references/notify.sh：多通道 sidecar helper，curl --fail（pre-flight 真 gate）、osascript argv 防注入、NOTIFY_CONFIG、mktemp。

🔴 經 codex + opus 兩輪對抗審查（leak 獵殺 + 品質），全抽象、零私密來源洩漏（NSFW/公司/個人/credential 全清）。