### PR TITLE
Bake in 'ask user for adversarial review before release' (skill_writing_patterns + loop-engineer v0.2.0)

### DIFF
--- a/docs/skill_writing_patterns.md
+++ b/docs/skill_writing_patterns.md
@@ -187,6 +187,19 @@ argument-hint: '"<project description>" [--port <number>] [--max-iterations <num
 
 ---
 
+## 發布前：對抗審查（互動詢問；public skill 必做）
+
+skill 寫完、**release 前主動問 user 要不要對抗審查**（不要等 user 自己喊——這是 leak 防線）：
+
+> 「skill 寫好了，要先派對抗審查再 release 嗎?
+> 1. 派 sub-agent 審　2. 不用　3. 其他（自訂輪數/順序/reviewer，例「兩輪，先 sub-agent 後 codex」）」
+
+- 每位 reviewer：**獨立、預設找碴**，分兩塊——
+  - 🔴 **LEAK 獵殺（public skill 紅線）**：NSFW／公司·客戶·同事／個人身份／真實 credential（token·chat_id·webhook）／真實機器名·絕對路徑·repo·IP，連「間接暗示私密來源」的指紋都抓。**範例一律抽象。**
+  - **品質**：pattern 合規（上述那些）＋ bug ＋ blind-runnable。
+- 多輪：修完一輪再審下一輪，全過才 release。
+- 🔴 **為什麼必做**：public skill 一旦 leak 就追不回（曾發生過）。codex + 獨立 LLM sub-agent 交叉審最穩。
+
 ## 套用 checklist（寫新 skill 時）
 
 ```
@@ -213,6 +226,9 @@ argument-hint: '"<project description>" [--port <number>] [--max-iterations <num
 - [ ] 長 workflow / 會跨 session？→ State persistence + resume 設計
 - [ ] 接 $ARGUMENTS？→ argument-hint + flag 說明
 - [ ] 自我改進 / iteration loop？→ cross-iteration history awareness
+
+[發布前]
+- [ ] release 前問 user 要不要對抗審查（public skill 必做：leak 掃 + 品質；codex + 獨立 sub-agent 交叉、可多輪）
 ```
 
 ---

--- a/loop-engineer/SKILL.md
+++ b/loop-engineer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: loop-engineer
 description: "Use when the user wants to set up an UNATTENDED, goal-driven evaluator-optimizer loop (generate → grade → iterate by reason-code) that a fresh-session agent runs hands-off while the human only watches push notifications. Interactively locks the spec via forcing questions, then emits a self-contained dispatch markdown + a channel-agnostic traffic-light notification protocol. NOT a time scheduler (that is /loop or cron) and NOT a recurring-push registrar (that is skill-cron) — this authors the one-shot unattended-loop spec a fresh session can run blind."
-version: 0.1.0
+version: 0.2.0
 triggers: ["/loop-engineer", "loop engineering", "loop engineer", "設計無人值守loop", "固化loop", "unattended loop", "evaluator-optimizer loop", "dispatch 換手文件"]
 ---
 
@@ -83,6 +83,17 @@ agent **絕對不能做**什麼?scope 邊界、禁止動作、只有人能決定
   - ✅ pre-flight 指令：`<跑通知測通的指令>`
   - ▶️ 開跑指令：`<丟給無人值守 session 的指令>`
   - 👀 之後 user 只顧 🟢🟡🔴、在 gate 挑最終選定。
+
+## 產出後：對抗審查（互動詢問，預設提供）
+
+dispatch 寫好後（尤其它會進 repo 或交給無人值守跑），**主動問 user 要不要先對抗審查再交付**（別等 user 自己喊）：
+
+> 「dispatch 已產生在 `<path>`，要先派對抗審查再交付嗎?
+> 1. 派 sub-agent 審　2. 不用　3. 其他（自訂輪數/順序/reviewer，例「兩輪，先 sub-agent 後 codex」）」
+
+- user 選 **3** → 照指定跑（例：先獨立 LLM sub-agent 一輪 → 再 codex 一輪）。
+- 每位 reviewer：**獨立、預設找碴**，先 🔴 **LEAK 獵殺**（dispatch 若進 repo：私密/credential/真實路徑機器名/內部專案，連間接指紋都抓）再 **品質**（spec 有沒有洞、約束/停止條件/可重現齊不齊、能不能 blind 跑）。
+- 多輪＝修完一輪再審下一輪；全過才交付。選 2 直接交付。
 
 ## Anti-patterns
 


### PR DESCRIPTION
把這 session 每次手動喊的對抗審查流程內建成互動步驟：

- **skill_writing_patterns.md**：新增『發布前：對抗審查（互動詢問；public skill 必做）』段 + checklist 加 [發布前] 行。寫完 skill、release 前主動問 user「要派對抗審查嗎? 1)派 2)不用 3)其他」；reviewer 獨立預設找碴、先 LEAK 獵殺(public 紅線)再品質、可多輪。
- **loop-engineer v0.2.0**：產出 dispatch 後同樣互動問要不要對抗審查再交付。

例互動：user 選 3 →「兩輪，先 sub-agent 後 codex」。