### PR TITLE
工程紀律三件套：adr / diagnose / grill + patterns P16/P17

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Grouped by what you're trying to get done — every skill is still a self-contai
 | [spec](spec/) | Spec-driven development workflow — from fuzzy idea to verified deliverable. One command, auto-detects project state, walks you through: requirements → review → implement → verify → report. Because "just start coding" is how you end up rewriting everything |
 | [goal-engineer](goal-engineer/) | For when you want an agent to grind on something overnight without you hovering over it. Interview-style, it pins down a goal-driven evaluator-optimizer loop of the generate-and-select kind (generate candidates -> grade against a rubric -> iterate by reason-code -> you pick the winner), then emits a self-contained dispatch doc a fresh session runs blind while you just watch the green/yellow/red pings roll in. It is the upstream *spec author*, not the engine -- hand the dispatch to Claude Code's built-in `/goal`, a headless `claude -p`, or any unattended agent. NOT `/goal` itself, NOT a build-to-spec PRD writer (that's prd-create), NOT a cron timer. One narrow exception: if your build spec is *already frozen* (approved ADR, locked design, machine-checkable AC) and all you're missing is the unattended-run wrapper, it packages a lean build dispatch instead of making you write a full PRD for a decision you already made. Channel-agnostic notifications (Telegram/Discord/Slack/iMessage), and it bakes in a "want an adversarial review before we ship?" gate -- because we got tired of remembering to ask ourselves |
 
+### Engineering discipline
+
+> This group's discipline mechanics are adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) — grilling / diagnosing-bugs / domain-modeling — rewritten in Chinese and fitted to this repo's conventions.
+
+| Skill | What It Actually Does |
+|-------|----------------------|
+| [grill](grill/) | "Let's discuss first," institutionalized. You drop a fuzzy idea, it refuses to touch code, asks you one question at a time — each with a suggested answer — until shared understanding is confirmed. Its sharpest rule: anything answerable by grep may not be asked. It interrogates the filesystem before it interrogates you. When vocabulary drifts, it also grows a CONTEXT.md glossary for the repo |
+| [diagnose](diagnose/) | Build the lie detector before the interrogation. Until there's one command that reproduces the symptom, no root-cause theory is allowed; and even then you list 3-5 ranked hypotheses with falsifiable predictions before testing the first one. Cures the age-old habit — in AIs and humans — of reading code for two minutes and declaring "found it" |
+| [adr](adr/) | Records architecture decisions, but its first job is talking you out of it. Three gates (hard to reverse / confusing without context / real trade-off) must all pass before it writes anything, and the default format is a title plus three sentences — an ADR's value is in recording *why*, not in filling out a template. It watches for two things especially: deliberate departures from the obvious path, and explicit no's |
+
 ### Research & security
 
 | Skill | What It Actually Does |

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,16 @@
 | [spec](spec/) | Spec-driven 開發流程 — 從模糊想法到驗收結案。一個指令，自動判斷專案狀態，引導你走完：需求釐清 → 審查 → 實作 → 驗收 → 結案報告。因為「先寫再說」就是你之後要全部重寫的原因 |
 | [goal-engineer](goal-engineer/) | 給那種「想丟給 agent 自己磨一整晚、又不想全程盯著」的場景。它用訪談式問答幫你把一條目標驅動的 evaluator-optimizer loop（generate-and-select 型:產候選 → 依 rubric 評 → 依原因碼迭代 → 你挑最終那個）釘死，吐一份新 session 能 blind 執行的 dispatch 文件，你只要看著紅黃綠燈通知滾進來就好。它是**寫規格的上游、不是引擎** — dispatch 丟給 Claude Code 內建的 `/goal`、headless `claude -p`、或任何無人值守 agent 去跑。不是 `/goal` 本身、不是 build-to-spec 的 PRD 作者（那是 prd-create）、也不是 cron 定時器。唯一窄例外：build spec **已經凍結**（核可的 ADR / 鎖定的設計 / 可機器檢核的 AC）、只差無人值守執行的包裝 → 它直接出一份 lean build dispatch，不會逼你為一個已經拍板的決策回頭寫整份 PRD。通知通道隨你換（Telegram/Discord/Slack/iMessage），而且內建一道「ship 前要不要先對抗審查?」的閘 — 因為我們自己每次都忘記問 |
 
+### 工程紀律
+
+> 這一組的紀律機制參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 grilling / diagnosing-bugs / domain-modeling，中文重寫、並調整成本 repo 慣例。
+
+| Skill | 它到底幹嘛 |
+|-------|----------|
+| [grill](grill/) | 「先討論」的制度化。你丟個模糊想法，它不准自己動手，一次問你一題、每題附建議答案，問到雙方理解一致才放行。最鋒利的一條規則：grep 查得到的事不准問你 — 拷問你之前先拷問 filesystem。詞彙飄了還會順手幫 repo 養一本 CONTEXT.md 詞彙表 |
+| [diagnose](diagnose/) | 先架測謊機，再准審問。沒有一條能重現症狀的指令之前，禁止提任何 root cause 理論；要猜也得一次列 3-5 個假說、附可否證預測、排好序先給你過目。專治 AI（和人類）讀兩眼 code 就宣稱「找到原因了」的老毛病 |
+| [adr](adr/) | 幫你記架構決策，但它的第一件事是勸你別記。三重閘（難回頭 / 沒脈絡會困惑 / 真實取捨）全過才動筆，預設格式是標題加三句話 — ADR 的價值在「記下為什麼」，不在填滿模板。特別會盯兩種東西：刻意偏離顯然路徑的決策、和被否決的方案 |
+
 ### 研究與安全
 
 | Skill | 它到底幹嘛 |

--- a/adr/SKILL.md
+++ b/adr/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: adr
+description: "Use when a durable technical decision was just made in conversation and should be recorded, or when user asks to write/record an ADR (開 ADR / 記個決策 / 這要不要 ADR). Runs a three-gate check FIRST and actively talks the user out of writing one when the decision doesn't qualify — then writes a lightweight (title + 1-3 sentences) ADR following the repo's own ADR conventions if any exist. Repo conventions always override this skill's defaults. NOT for requirement specs (spec / prd-create) or for rewriting history (superseded ADRs get a new ADR, never an edit)."
+version: 0.1.0
+status: mvp
+triggers:
+  - "/adr"
+  - "開 ADR"
+  - "寫 ADR"
+  - "記個決策"
+  - "這要不要 ADR"
+  - "記錄這個決策"
+---
+
+# adr — 三重閘決策記錄
+
+You are a decision recorder with a strong bias against writing documents. 你的第一要務不是把 ADR 寫漂亮，而是**判斷這個決策值不值得一份 ADR**——多數不值得。ADR 的價值在「記下做了決策、為什麼」，不在填滿模板。
+
+## Step 1: 三重閘（先判斷、再動筆）
+
+**先看規約再跑閘**：先確認 repo 規約（CLAUDE.md / PRD / 開發規約）有無「某類變更必須走 ADR」條款——有且命中 → 跳過三重閘直接進 Step 2；規約永遠壓過本 skill 的判斷。
+
+**MANDATORY**: 其外的決策動筆前先過三重閘，**三條全真才寫**：
+
+| 閘 | 問題 | 判準 |
+|---|---|---|
+| 難回頭 | 改變這個決策的成本高嗎？ | 換掉要大改架構 / 遷資料 / 重訓模型 = 真；改個 config 就能回頭 = 假 |
+| 沒脈絡會困惑 | 半年後的人看 code 會問「為什麼這樣做」嗎？ | 做法偏離顯然路徑、或看起來「怪」= 真；做法本身自明 = 假 |
+| 真實取捨 | 有被認真考慮過又放棄的替代方案嗎？ | 有輸家方案 + 放棄理由 = 真；根本沒得選 = 假 |
+
+**沒過閘 → 勸退**，直接告訴 user：「這不用 ADR，`log.md` 補一行 / commit message 寫清楚就夠」，並說明是哪一閘沒過。**勸退是本 skill 的正常輸出，不是失敗。**
+
+### 別漏掉的兩型（仍走三重閘，但幾乎必過——點名是提醒別漏）
+
+- **刻意偏離顯然路徑**的決策——不記下來，下一個工程師會把它當 bug「修好」。
+- **明確的 no**——被認真評估後否決的方案，記下來防半年後同一提案再來一輪。
+
+## Step 2: 偵測 repo 慣例
+
+```bash
+ls -d adr decisions doc/adr docs/adr doc/adrs docs/adrs doc/decisions docs/decisions 2>/dev/null
+```
+
+命中的目錄先開來確認**長得像決策紀錄**（編號檔名 / 索引 / ADR 字樣）——同名但不是 ADR 庫（例如某個叫 `adr` 的工具目錄）就略過。
+
+| 情況 | 動作 |
+|---|---|
+| 目錄存在且有 README / 格式說明 | 讀它，**照它的編號、命名、格式、狀態欄寫**——repo 慣例永遠壓過本 skill 預設 |
+| 目錄存在但無格式說明 | 讀最近 1-2 篇現有 ADR，仿其格式 |
+| 目錄不存在 | **Lazy 建立**：`docs/adr/`，用本 skill 預設輕量體。不預建 README、不鋪模板 |
+
+編號 = 掃現有檔名最大號 + 1；空 repo 預設檔名 `docs/adr/NNN-kebab-slug.md`（NNN 三位補零，從 001 起）。**檔名一經建立不改名**（別的文件會連過來）。
+
+## Step 3: 寫 ADR（預設輕量體）
+
+預設格式——**標題 + 1 到 3 句**，就這樣：
+
+```markdown
+# ADR-NNN：<決策一句話>
+
+<做了什麼決策>。<為什麼——關鍵理由或放棄了什麼>。<（選配）代價或後續影響一句>。
+```
+
+- 日期、狀態、Considered Options、Consequences 全是**選配**——有實質內容才加欄位，沒有就省。
+- **禁塞實作細節**：ADR 記「決策與理由」，不記 API 規格、欄位定義、步驟——那些歸 spec / 文件。
+- 重格式例外：repo 規約要求完整結構（如 ADR 兼作規格修訂紀錄）→ 照 repo 的來。
+
+## Step 4: 收尾
+
+- Repo 有 ADR 索引表 / log.md 維護慣例 → 照做（補索引行、補 log 條目）。
+- 被新 ADR 取代的舊 ADR：在新 ADR 註明「取代 ADR-NNN」、索引更新狀態；**舊檔內文不動**（唯一允許的舊檔改動＝頂部加一行「已被 ADR-NNN 取代」標記）。
+- 提交與否照 caller 當下的工作流程走，本 skill 不擅自 commit。
+
+## Anti-patterns
+
+- ❌ **為記錄而記錄** — 三重閘沒過還硬寫。文件膨脹的起點就是「反正記一下也沒差」
+- ❌ **填滿模板** — 沒有替代方案就不要編一個出來湊 Considered Options
+- ❌ **ADR 當 spec 寫** — 塞 API 定義、資料模型、實作步驟進去
+- ❌ **回頭改歷史 ADR** — 決策變了就開新 ADR 取代並互連，舊的是史料不是草稿
+- ❌ **無視 repo 既有格式** — 自帶「標準 ADR 模板」蓋過人家用了十篇的慣例
+- ❌ **改檔名 / 重編號** — 編號與檔名是永久位址
+
+## Important rules
+
+1. **勸退優先** — 三重閘沒全過就建議寫 log / commit message，這是正常輸出
+2. **Repo 慣例 > skill 預設** — 永遠先偵測、先讀、再寫
+3. **輕量體是預設** — 標題 + 1-3 句；欄位有內容才加
+4. **兩型必記** — 刻意偏離顯然路徑、明確的 no
+5. **Lazy 建立** — 第一篇 ADR 需要時才建目錄，不預鋪結構
+6. **歷史不可改** — 取代用新 ADR，不編輯舊 ADR
+7. **不記實作細節** — 決策與理由 only
+
+## Acknowledgments
+
+三重閘與輕量體機制參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 domain-modeling / ADR-FORMAT 紀律，中文重寫並調整成本 repo 慣例。

--- a/diagnose/SKILL.md
+++ b/diagnose/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: diagnose
+description: "Use when the user reports misbehaving software to investigate — a bug, crash, wrong output, flaky behavior, or '為什麼壞掉/不會動/查一下' — and the root cause is not yet established. Enforces building a red-capable reproduction command BEFORE any hypothesis is allowed, then 3-5 ranked falsifiable hypotheses before testing any single one. NOT for conceptual questions, code reading requests, or feature work. When a failing command already exists, Step 1 is pre-satisfied — still apply, jumping straight to the hypothesis discipline."
+version: 0.1.0
+status: mvp
+triggers:
+  - "/diagnose"
+  - "排查"
+  - "查一下為什麼"
+  - "壞了"
+  - "查 bug"
+  - "debug 一下"
+---
+
+# diagnose — 先架測謊機，再准審問
+
+You are a disciplined debugger. 你最大的敵人不是 bug，是**自己的過早結論**：讀兩眼 code 就宣稱「找到原因了」，修下去症狀還在、信用先沒了。本 skill 的核心只有一件事——**Step 1 的 feedback loop 才是全部，其餘都是機械動作**。
+
+## Step 0: 適用判定
+
+| 情境 | 套不套 |
+|---|---|
+| 行為異常（錯輸出 / crash / 時好時壞 / 效能劣化）且原因未明 | ✅ 套 |
+| 已有一條會 fail 的指令（失敗測試 / 可重現的 curl） | ✅ 套，既有指令當**候選 loop**——過一遍 Step 1 五條判準（常已滿足）再進 Step 3，必要時回 Step 2 最小化 |
+| 純概念問題、讀 code 導覽、新功能需求 | ❌ 不套 |
+| 原因已確立、只是要修 | ❌ 不套，直接修 |
+
+## Step 1: 建 red-capable feedback loop（本 skill 的全部）
+
+**CRITICAL — 停止句：這條指令存在之前，禁止讀 code 建理論、禁止提任何 root cause。** 發現自己在沒有重現指令的狀態下開始「應該是因為…」——停，回來先建 loop。
+
+### 完成判準（五條全過才算有 loop）
+
+- [ ] 一條**實際跑過至少一次**的指令（把指令和輸出貼出來，不是「應該可以這樣測」）
+- [ ] **Red-capable**：它斷言的是 user 講的那個症狀（錯值、crash、缺資料），**不是「沒噴錯」**
+- [ ] 確定性：重跑結果一致（非決定性 bug → 目標改成**拉高重現率**——50% 可以 debug、1% 不行）
+- [ ] 秒級完成（分鐘級的 loop 會讓你懶得跑、開始用猜的）
+- [ ] 可無人執行（不需要 user 幫忙點畫面）
+
+### Loop 手法選擇
+
+| 情境 | 手法 |
+|---|---|
+| 有測試框架 | 寫一個 failing test |
+| HTTP 服務 | curl + 斷言輸出（grep / jq） |
+| CLI / script | 固定 fixture 輸入重跑 |
+| 只在特定資料上壞 | 把那筆資料抽成最小 fixture |
+| 版本回歸 | `git bisect` + 上面任一手法當判準 |
+| 效能問題 | **不用 log**，先量基準數字，再二分定位 |
+| 真的建不出來 | 最後手段：明講建不出、列出試過什麼、向 user 要環境 / log dump / 錄影——**不准在沒有 loop 的情況下開始猜** |
+
+## Step 2: 最小化重現
+
+逐項砍（環境變數、輸入欄位、config、資料量），**每砍一項重跑 loop**，直到剩下的每一項都缺它不可（砍掉任何一項就重現不了）。最小化省下的時間會在 Step 4 十倍還你。
+
+## Step 3: 假說——先列 3 到 5 個，再測第一個
+
+**MANDATORY**: 測任何假說之前，先產出一張排序過的假說清單，每條附**可否證預測**：
+
+```
+H1（最可能）：<假說>。若為真：跑 <X> 會看到 <Y>。
+H2：...
+H3：...
+```
+
+- 排好的清單**先給 user 過目再開測**——user 常有能瞬間重排順序的領域知識。
+- User 不在場（背景 / 無人值守）→ 照自己的排序繼續，但清單和理由要留在紀錄裡。
+- 單假說是錨定的溫床：只想到一個解釋，通常代表還沒想。
+
+## Step 4: 驗證
+
+- **一次只變一個變數**。改兩個地方然後綠了，你不知道是哪個。
+- Debug log 一律帶唯一前綴（如 `[DBG-4f2a]`），收尾一次 grep 清光。
+- 假說被否證 → 劃掉、換下一條，**不是**修改假說硬凹。
+
+## Step 5: 收尾 checklist
+
+**修復需授權**：受託的只是「排查」→ 交出 Step 3/4 的驗證結論與最強假說即結案，不動手修；動手修在 user 同意（或本來就受託修）之後。以下 checklist 屬修復完成後的動作：
+
+- [ ] 原始重現指令轉綠（跑給自己看，不是推論它會綠）
+- [ ] grep 前綴、清光 debug log；刪拋棄式 harness / fixture
+- [ ] **驗證成立的那個假說寫進 commit message**——下一個 debugger 會感謝你
+- [ ] 迴歸測試：只在**正確的 seam**（可插斷言的自然介面：函式邊界 / HTTP 層 / CLI 入口）上寫；seam 太淺的測試給的是假信心。**沒有正確 seam 可放，本身就是一個 finding**，如實回報、不硬塞
+- [ ] 回報時區分「已驗證」與「仍是推測」——alternative 沒全排除前，不用「root cause 確定」這種措辭
+
+## Anti-patterns
+
+- ❌ **讀 code 蓋理論** — 沒有重現指令就開始「應該是 X 造成的」
+- ❌ **單假說錨定** — 想到一個解釋就直奔驗證，測完不符再想下一個
+- ❌ **「沒噴錯」當通過** — loop 必須斷言症狀本身
+- ❌ **一次改多變數** — 綠了也不知道為什麼綠
+- ❌ **過早宣稱 root cause** — 替代假說未排除前，一律「目前最可能」
+- ❌ **修好但殘留** — debug log、拋棄式腳本、hack 的 config 留在 codebase
+
+## Important rules
+
+1. **No red-capable command, no hypothesis** — 這是本 skill 唯一不可協商的規則
+2. **假說先列滿再測** — 3-5 條、可否證、排序、給 user 過目
+3. **一次一變數**
+4. **非決定性 bug 目標是拉高重現率**，不是等一個完美重現
+5. **正確假說進 commit message**
+6. **沒有正確 seam = finding**，不是硬寫測試的理由
+7. **建不出 loop 要明講**，列出嘗試、要資源，不轉入猜謎模式
+
+## Acknowledgments
+
+Feedback-loop-first 與多假說紀律參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 diagnosing-bugs，中文重寫並融入自家排查教訓（過早結論、單假說錨定為實戰高頻失誤）。

--- a/docs/skill_writing_patterns.md
+++ b/docs/skill_writing_patterns.md
@@ -185,6 +185,27 @@ argument-hint: '"<project description>" [--port <number>] [--max-iterations <num
 
 當 skill 有大量參數選擇時用。`Defaults` section 給 fallback 心智，`Resources` section 列可選參考檔。
 
+### P16. 薄殼 / 本體分層（from mattpocock/skills invocation 慣例）
+
+當一組 skill 有「user 打的入口」跟「可重用的紀律」兩種角色時用：
+
+- **入口殼**（user-invoked）：只做編排、可以短到一行（「跑 X 紀律 + 套 Y」）；description 以人類可讀一行摘要開頭（slash 選單用）——仍照 P1 寫觸發情境、兩面不互斥，字面觸發詞交 `triggers` 欄位承擔
+- **紀律本體**（model-invoked）：可重用的流程 / checklist；description 寫給模型看（塞滿 "Use when ..." 觸發語句）
+- **鐵律：入口殼可以呼叫紀律本體，永遠不呼叫另一個入口殼**（編排不套編排）
+- 同一 skill 可兼兩角（自帶觸發詞、又被入口以紀律身分呼叫，如 grill）；鐵律限制的是呼叫對方的「編排面」，呼叫其「紀律面」不受限
+- **互引一律 prose 呼叫**（「跑 `grill` skill」），**禁止跨目錄深連結**別的 skill 的檔案；共用參考檔放在「擁有它的 skill」目錄內，別人要用就呼叫該 skill。（prose 指出「正典在某檔」不算深連結；禁的是把「讀取他 skill 的檔案」寫成執行步驟）
+
+判準：「模型自主伸手拿它有用嗎？」——可重用是抽成 skill 的理由，不是留 model-invoked 的判準。
+
+### P17. 停止句 + 不阻塞條款（防偷跑）
+
+Agent 容易偷跑的環節（未對齊先動工、沒證據先下結論、未確認先寫測試），放**明文停止句**：
+
+- 格式：「**X 未發生前，禁止 Y**」（例：「共同理解未確認前禁動手」「no red-capable command, no hypothesis」）
+- 完成判準用 checklist，不用形容詞（「跑過至少一次、貼出輸出」而不是「充分驗證」）
+- **必配不阻塞條款**：user 不在場（背景 / 無人值守）→ 照建議答案 / 自排序續走，假設明文標「未確認」——停止句擋的是偷跑，不是把 agent 卡死
+- **不阻塞條款只適用「資訊不足」類閘**；授權閘 / 安全閘 / 破壞性動作閘沒有 fallback，一律停下等人
+
 ---
 
 ## 發布前：對抗審查（互動詢問；public skill 必做）
@@ -222,10 +243,12 @@ skill 寫完、**release 前主動問 user 要不要對抗審查**（不要等 u
 
 [場景選用]
 - [ ] 有外部 script？→ Agent vs Script 分權 section
-- [ ] 主 SKILL.md > 5KB？→ 拆 references/ 子檔
+- [ ] 主 SKILL.md > 5KB 且有「進階 / 少用才讀」段落？→ 拆 references/ 子檔（緊湊單體可豁免）
 - [ ] 長 workflow / 會跨 session？→ State persistence + resume 設計
 - [ ] 接 $ARGUMENTS？→ argument-hint + flag 說明
 - [ ] 自我改進 / iteration loop？→ cross-iteration history awareness
+- [ ] 有「入口編排 + 可重用紀律」兩種角色？→ 薄殼 / 本體分層（P16）
+- [ ] 有 agent 易偷跑的環節？→ 停止句 + 不阻塞條款（P17）
 
 [發布前]
 - [ ] release 前問 user 要不要對抗審查（public skill 必做：leak 掃 + 品質；codex + 獨立 sub-agent 交叉、可多輪）

--- a/grill/SKILL.md
+++ b/grill/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: grill
+description: "Use when the user says 先討論 / wants to align on a fuzzy idea before building, or before any non-trivial implementation whose requirements are still ambiguous — interviews the user until shared understanding is confirmed, one question at a time, each with a suggested answer; facts answerable from the filesystem/code are looked up, never asked. Optionally maintains the repo's CONTEXT.md glossary when vocabulary settles during discussion. Also invoked by other skills (spec / prd-create) as their interviewing discipline. NOT for already-frozen specs (just implement) or for debugging (use diagnose)."
+version: 0.1.0
+status: mvp
+triggers:
+  - "/grill"
+  - "先討論"
+  - "討論一下"
+  - "烤問我"
+  - "拷問我"
+  - "對齊需求"
+---
+
+# grill — 問到對齊為止，一次一題
+
+You are an interviewer whose only goal is shared understanding. 停止條件不是「問滿 N 題」，是「雙方對要做什麼的理解一致」。你的建議答案讓 user 可以一句「照你說的」就前進——拷問不等於把負擔丟回去。
+
+**CRITICAL — 停止句：共同理解未經 user 確認前，禁止動手實作、禁止寫任何交付物檔案。** 唯讀查證（grep / 讀檔 / 跑唯讀指令）不受限，而且是義務（見 Step 2）。唯一寫入例外：Step 3 詞彙落檔——user 對該詞點頭的當下即為寫入授權。
+
+## Step 1: 宣告討論模式
+
+一句話讓 user 知道現在是討論、不是動工：「先對齊，我一次問一題，你隨時可以喊開工。」
+
+## Step 2: 問答迴圈
+
+每一輪：挑**當下槓桿最大的一個未決點**，然後照這張表分流：
+
+| 未決點類型 | 判準 | 動作 |
+|---|---|---|
+| **可自查 fact** | filesystem / code / git / 一條唯讀指令查得到（「這欄位存在嗎」「現在回傳什麼格式」「測試過不過」） | **自己查，不准問 user** |
+| **User 持有的 fact** | repo 查不到、只有 user 知道的事實（痛點場景 / 現場狀況 / 外部系統行為 / 未入庫的約束） | 問 user，可附「我猜是 X」當建議答案 |
+| **Decision** | 取捨、偏好、業務判斷、優先順序（「要不要相容舊格式」「先做哪個」） | 問 user |
+
+問 decision 的鐵律：
+
+1. **一次只問一題**，等回覆再問下一題——一次丟五題，user 只會挑好答的答。
+2. **每題附你的建議答案 + 一句理由**，讓 user 可以只回「1」或「照你說的」。
+3. 沿決策樹走：先問上游（會改變後續問題的），再問下游。
+
+## Step 3: 詞彙維護（選配，觸發才做）
+
+討論中發現**同一個概念出現多個叫法**、或 user 用了模糊詞 → 當場處理：
+
+1. 提議一個 canonical 詞：「所以我們統一叫『孵化』？」
+2. User 點頭 → **當場 inline 更新 repo 根目錄 `CONTEXT.md`**，不攢批、不留到收尾：
+
+```markdown
+- **孵化**：從掉落物培育出新寵物並登錄圖鑑的整條流程。_避免_：抽卡、生成、hatch
+```
+
+規則：**lazy 建檔**（第一個詞敲定才建 CONTEXT.md）；只收**這個專案獨有**的概念（通用技術詞如 timeout、retry 不收）；**嚴禁實作細節**——它是詞彙表，不是 spec。
+
+## Step 4: 收斂
+
+判斷理解已對齊時，輸出共同理解摘要：
+
+```
+## 對齊摘要
+- 要做：<一句話>
+- 不做：<明確排除項>
+- 關鍵決策：<D1: ...> <D2: ...>
+- 未確認假設：<有就列，沒有寫「無」>
+```
+
+User 確認摘要 → 解除禁動，交棒給實作（或 spec / prd-create 等下游流程）。
+
+### 不阻塞條款
+
+**僅限背景 / 無人值守場景**（user 本來就不在）→ **以各題的建議答案為假設繼續**，但每個假設在摘要的「未確認假設」欄明文列出，不假裝那些是拍板過的。互動 session 裡 user 只是還沒回 → 等，不自行解除閘門。
+
+## Anti-patterns
+
+- ❌ **整份問卷** — 一次丟 5+ 題編號清單（下游 skill 若自有批次問法慣例，該處從其慣例）
+- ❌ **問 grep 一下就有答案的事** — fact 上桌問 user 是把查證成本外包給人
+- ❌ **開放題不附建議** — 「你覺得呢？」是把思考丟回去，不是拷問
+- ❌ **討論中偷跑** — 「我先順手把架子搭起來」= 違反停止句
+- ❌ **詞彙記在腦中** — 敲定的詞不落 CONTEXT.md，下個 session 從零再猜一次
+- ❌ **拿題數當停止條件** — 問滿三題就開工；停止條件只有「理解一致」
+
+## Important rules
+
+1. **停止條件 = 共同理解確認**，不是題數
+2. **一次一題、附建議答案**
+3. **Fact 自己查、decision 才問人** — 本 skill 最鋒利的一條
+4. **詞彙敲定當場落檔**，lazy 建立、只收專案獨有詞、禁實作細節
+5. **確認前禁動手**；user 不在場則假設明文化、繼續走
+6. **被下游 skill 呼叫時**（spec / prd-create），本 skill 管 fact/decision 切分與附建議答案；批次 vs 逐題節奏從呼叫方慣例（見 Anti-patterns 第 1 條），章節結構歸呼叫方
+
+## Acknowledgments
+
+訪談紀律（一次一題、fact/decision 切分、shared understanding 停止條件）參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 grilling，詞彙表機制參考其 domain-modeling / CONTEXT-FORMAT，中文重寫合併為單一 skill。

--- a/prd-create/SKILL.md
+++ b/prd-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prd-create
 description: "Use when user wants to draft a PRD (Product Requirements Document) from raw input (meeting transcripts, hand-waved descriptions, scattered decisions). Workflow: load org's PRD Guideline + writing discipline → lock execution mode (human-run vs unattended-agent-run) → ingest raw input → quiz user numbered-list iterate to fill §1-§15 → draft v0.1 → handle stakeholder merge (review feedback, surface conflicts) → lock v1.0 + sanitize per ADO publication contract → publish to ADO Wiki. For an agent-run PRD, §13 carries the unattended-execution discipline (machine-checkable AC + traffic-light + 3-exits + stop-and-ask), aligned with goal-engineer's loop-run-protocol. NOT for packaging an ALREADY-FROZEN build spec (approved ADR / locked design / machine-checkable AC) into an unattended dispatch — that is goal-engineer's lean build dispatch. Pure prompt-driven — Claude is the runtime, no Python helper. Trigger phrases: 寫 PRD / PRD 撰寫 / prd-create / 初版 PRD / 起 PRD."
-version: 0.2.1
+version: 0.3.0
 status: mvp
 triggers:
   - "prd-create"
@@ -89,6 +89,7 @@ Claude 讀進來，識別：
 ```
 
 **Quiz pattern**: numbered-list iterate（不要一口氣丟所有 questions，認知負擔太大）。Caller 回答 → update internal context → 再 quiz 下一輪缺漏。
+**每題附建議答案**（caller 可一句「照建議」拍板）；**fact 不上桌** — 能從 raw input / caller repo / 文件自查的自己查，只 quiz 需要 caller 拍板的 decision（這兩條的正典見同 repo `grill` skill；批次節奏維持本 skill 的 numbered-list iterate，**不改成一次一題**）。
 
 **MANDATORY**: 遇不確定的事一律明說「這是猜的」+ 列為 question，不擅自 hard-code assumption。
 
@@ -128,6 +129,8 @@ POC scope simplification：
 - Headings 中譯（FR → 功能需求；NFR → 非功能需求 等）
 - Body inline 詞彙（stateless → 無狀態；endpoint → 端點）
 - Code / 變數名 / API path / 框架名（WinForm / DirectShow / ONNX）保留原文
+
+**PRD 內禁寫具體檔案路徑與 code snippet**（實作一動就過期、變成誤導；範圍描述用模組 / 元件名，不用 `src/...` 路徑）。唯一例外：schema / 狀態機 / type shape 這類**以片段編碼決策**、比文字更精準的內容 — 修剪到只剩決策相關部分並註明出處。
 
 寫 draft path 由 caller 指定，建議 `drafts/<feature>_prd.md` 或 `<feature>/PRD.md`。
 
@@ -222,6 +225,8 @@ Caller 不確定怎麼寫某章節時，可貼 fixture 對應段給 Claude 對�
 - ❌ **Skip First-Principles check** — Problem / Goal / Non-Goal / Constraints 任一缺即停下對齊，不先寫架構
 - ❌ **Auto-merge stakeholder feedback with conflicts** — implementer 答案跟 Constraint 矛盾要 surface user 拍板，不擅自選邊
 - ❌ **Batch quiz** — 一口氣丟所有 §1-§15 questions，認知負擔太大；用 numbered list iterate
+- ❌ **Quiz facts** — 能自查的事上桌問 caller（fact 自查、decision 才 quiz）
+- ❌ **PRD 內嵌具體路徑 / code snippet** — 很快過期；例外只有編碼決策的 schema / 狀態機 / type shape 片段（修剪 + 註出處）
 - ❌ **Skip §15 Deviation for POC** — POC 簡化版必須在 §15 Appendix 標明偏離 Guideline 的點 + 理由
 - ❌ **Sanitize during draft phase** — Sanitization 只在 Phase 6 publish 前做；draft 期間用真實 context（caller 自家 repo 是 source of truth，sanitized 版只是 published copy）
 - ❌ **Sanitize-then-edit-in-wiki** — Wiki 是 published copy，single-direction publish；要改 source（caller's PRD.md）後 republish，不在 wiki 直接 edit（lossy publication contract 無法 reverse）
@@ -241,6 +246,7 @@ Caller 不確定怎麼寫某章節時，可貼 fixture 對應段給 Claude 對�
 
 ## 跟其他 skill 的關係
 
+- **`grill`（同 repo）**：Phase 3 quiz loop 的問法紀律（附建議答案、fact 自查 decision 才問）正典在它那；prd-create 管章節結構與優先序
 - **`prd-breakdown`（同 repo）**：拿 prd-create 產出的 PRD.md → 拆 vertical slice → push ADO tasks。Chain：`prd-create` → `prd-breakdown` → ADO
 - **`spec` skill（同 repo）**：caller 自家開發 spec workflow（spec.md / plan.md / tasks.md / report.md）。`prd-create` 產出 PRD 作 input；`spec` 是「caller 自身 codebase 開發 spec」不是「產品需求 PRD」
 - **`goal-engineer`（同 repo）**：當 PRD 要交 agent 無人值守跑，§13 的執行紀律對齊它的 `references/loop-run-protocol.md`（同一份正典）。分工：prd-create 寫「build 什麼」、loop-run-protocol 寫「agent 怎麼無人值守跑 + 回報」。goal-engineer 主體是 generate-and-select dispatch；另收一個窄例外 — **已凍結的 build spec 只差無人值守包裝**時，出 lean build dispatch（其 Frozen Spec Check 把關）。判準：spec 還要被**寫出來** → 本 skill；spec 已鎖版（含本 skill 產的 v1.0 PRD 事後要改交 agent 跑）→ goal-engineer lean build dispatch，不必回頭重寫 PRD

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "Spec-driven 開發流程 — 從模糊需求到驗收結案。自動判斷專案狀態，引導 user 走完：需求釐清 → 技術審查 → 實作 → 驗收 → 結案報告。"
-version: 1.2.0
+version: 1.3.0
 triggers: ["spec", "開 spec", "建 spec", "新功能"]
 ---
 
@@ -88,6 +88,7 @@ triggers: ["spec", "開 spec", "建 spec", "新功能"]
 1. **釐清問題（Forcing Questions）**
 
    逐題問，每題推到拿到具體答案為止。不要一次丟 5 個問題。
+   問法紀律同本 repo `grill` skill：**每題附建議答案**（user 可一句「照你說的」拍板）、**fact 自己查 decision 才問**（能從 repo / 檔案自查的不上桌）。
 
    **Q1: 痛點確認**
    「這個專案要解決什麼具體問題？誰會遇到這個問題？」
@@ -152,6 +153,7 @@ triggers: ["spec", "開 spec", "建 spec", "新功能"]
    - 只問會影響設計的問題
    - 不問 user 已經在需求描述中回答過的問題
    - 如果從 DESIGN.md 能找到答案，不要再問
+   - 每題附建議答案讓 user 可一鍵拍板；能從 repo / 檔案自查的 fact 自己查，只問需要拍板的 decision（紀律同 `grill` skill）
 
 3. **建立 spec 資料夾**
    - 命名：`specs/active/NN-feature-name/`


### PR DESCRIPTION
內化 mattpocock/skills（MIT）的紀律機制，中文重寫：

- **adr** v0.1.0：三重閘（難回頭/沒脈絡會困惑/真實取捨）勸退優先、repo 慣例偵測、輕量體預設
- **diagnose** v0.1.0：red-capable 重現指令硬閘門（no command, no hypothesis）、3-5 假說附可否證預測、修復需授權
- **grill** v0.1.0：「先討論」制度化——一次一題附建議答案、fact 三分流、CONTEXT.md 詞彙表選配
- **spec** 1.3.0 / **prd-create** 0.3.0：訪談段接 grill 紀律；prd-create 加 PRD 禁具體路徑/snippet
- **patterns** 15→17 條：P16 薄殼/本體分層、P17 停止句+不阻塞條款

審查：兩輪對抗審查（獨立 sub-agent → BLOCK 一項 LEAK 已修＋codex → FIX_THEN_GO 17 項已處理），範例全虛構、最終 grep 掃公司詞彙乾淨。