### PR TITLE
docs: planning-skill routing guide (which one to reach for) + prd-create↔spec route check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Grouped by what you're trying to get done — every skill is still a self-contai
 | [spec](spec/) | Spec-driven development workflow — from fuzzy idea to verified deliverable. One command, auto-detects project state, walks you through: requirements → review → implement → verify → report. Because "just start coding" is how you end up rewriting everything |
 | [goal-engineer](goal-engineer/) | For when you want an agent to grind on something overnight without you hovering over it. Interview-style, it pins down a goal-driven evaluator-optimizer loop of the generate-and-select kind (generate candidates -> grade against a rubric -> iterate by reason-code -> you pick the winner), then emits a self-contained dispatch doc a fresh session runs blind while you just watch the green/yellow/red pings roll in. It is the upstream *spec author*, not the engine -- hand the dispatch to Claude Code's built-in `/goal`, a headless `claude -p`, or any unattended agent. NOT `/goal` itself, NOT a build-to-spec PRD writer (that's prd-create), NOT a cron timer. One narrow exception: if your build spec is *already frozen* (approved ADR, locked design, machine-checkable AC) and all you're missing is the unattended-run wrapper, it packages a lean build dispatch instead of making you write a full PRD for a decision you already made. Channel-agnostic notifications (Telegram/Discord/Slack/iMessage), and it bakes in a "want an adversarial review before we ship?" gate -- because we got tired of remembering to ask ourselves |
 
+> **Which planning skill do I reach for?** These overlap because they share the same interview-then-document DNA — but they sit at different layers:
+>
+> | You have… | Reach for |
+> |---|---|
+> | A pile of notes/requests → a **product requirements doc for others** to read (ships to a wiki) | `prd-create` |
+> | A finished PRD → **Azure DevOps work items** | `prd-breakdown` |
+> | A fuzzy idea *you* will build in your own codebase, **all the way to verified code** | `spec` |
+> | One **hard-to-reverse decision** just made, worth recording *why* | `adr` |
+> | A goal to hand an agent to **grind unattended overnight** | `goal-engineer` |
+>
+> The two confused most: **prd-create vs spec** — prd-create writes a product doc *for stakeholders* and stops at the doc; spec walks *your own* build from requirements to verified code. **spec vs adr** — spec is a whole feature's design+build lifecycle; adr is a *single* consequential decision pulled out into its own record (only if it clears the three gates). `grill` isn't a competitor — it's the shared "one question at a time" interview discipline the others reuse.
+
 ### Engineering discipline
 
 > This group's discipline mechanics are adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) — grilling / diagnosing-bugs / domain-modeling — rewritten in Chinese and fitted to this repo's conventions.

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,18 @@
 | [spec](spec/) | Spec-driven 開發流程 — 從模糊想法到驗收結案。一個指令，自動判斷專案狀態，引導你走完：需求釐清 → 審查 → 實作 → 驗收 → 結案報告。因為「先寫再說」就是你之後要全部重寫的原因 |
 | [goal-engineer](goal-engineer/) | 給那種「想丟給 agent 自己磨一整晚、又不想全程盯著」的場景。它用訪談式問答幫你把一條目標驅動的 evaluator-optimizer loop（generate-and-select 型:產候選 → 依 rubric 評 → 依原因碼迭代 → 你挑最終那個）釘死，吐一份新 session 能 blind 執行的 dispatch 文件，你只要看著紅黃綠燈通知滾進來就好。它是**寫規格的上游、不是引擎** — dispatch 丟給 Claude Code 內建的 `/goal`、headless `claude -p`、或任何無人值守 agent 去跑。不是 `/goal` 本身、不是 build-to-spec 的 PRD 作者（那是 prd-create）、也不是 cron 定時器。唯一窄例外：build spec **已經凍結**（核可的 ADR / 鎖定的設計 / 可機器檢核的 AC）、只差無人值守執行的包裝 → 它直接出一份 lean build dispatch，不會逼你為一個已經拍板的決策回頭寫整份 PRD。通知通道隨你換（Telegram/Discord/Slack/iMessage），而且內建一道「ship 前要不要先對抗審查?」的閘 — 因為我們自己每次都忘記問 |
 
+> **規劃類 skill 該用哪顆？** 它們會像，是因為共用同一套「先訪談再產文件」的 DNA — 但坐在不同樓層：
+>
+> | 你手上是… | 用這顆 |
+> |---|---|
+> | 一坨筆記／需求 → 要一份**給別人看的產品需求書**（會上 wiki） | `prd-create` |
+> | 一份完成的 PRD → **Azure DevOps 工作項** | `prd-breakdown` |
+> | 一個模糊想法，**你自己**要在 codebase 裡一路做到**驗收過的 code** | `spec` |
+> | 剛做了一個**難回頭的決策**，值得記下**為什麼** | `adr` |
+> | 一個目標，要丟給 agent **無人值守整晚磨** | `goal-engineer` |
+>
+> 最常被搞混的兩組：**prd-create vs spec** — prd-create 寫給 stakeholder 看的產品文件、停在文件；spec 走你自己 codebase 從需求到驗收過的 code。**spec vs adr** — spec 是整個 feature 的設計＋實作生命週期；adr 是其中**單一**關鍵決策抽出來的獨立紀錄（過三重閘才寫）。`grill` 不是競爭者 — 它是其他幾顆共用的「一次問一題」訪談紀律。
+
 ### 工程紀律
 
 > 這一組的紀律機制參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 grilling / diagnosing-bugs / domain-modeling，中文重寫、並調整成本 repo 慣例。

--- a/prd-create/SKILL.md
+++ b/prd-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prd-create
 description: "Use when user wants to draft a PRD (Product Requirements Document) from raw input (meeting transcripts, hand-waved descriptions, scattered decisions). Workflow: load org's PRD Guideline + writing discipline → lock execution mode (human-run vs unattended-agent-run) → ingest raw input → quiz user numbered-list iterate to fill §1-§15 → draft v0.1 → handle stakeholder merge (review feedback, surface conflicts) → lock v1.0 + sanitize per ADO publication contract → publish to ADO Wiki. For an agent-run PRD, §13 carries the unattended-execution discipline (machine-checkable AC + traffic-light + 3-exits + stop-and-ask), aligned with goal-engineer's loop-run-protocol. NOT for packaging an ALREADY-FROZEN build spec (approved ADR / locked design / machine-checkable AC) into an unattended dispatch — that is goal-engineer's lean build dispatch. Pure prompt-driven — Claude is the runtime, no Python helper. Trigger phrases: 寫 PRD / PRD 撰寫 / prd-create / 初版 PRD / 起 PRD."
-version: 0.3.0
+version: 0.3.1
 status: mvp
 triggers:
   - "prd-create"
@@ -52,6 +52,8 @@ User 觸發詞如「寫 PRD」「prd-create」「起 PRD」時走這條。
 **同時鎖定執行模式**：這份 PRD 是 **人跑** 還是 **agent 無人值守跑**?（POC / Production scope 也一併確認）。agent-run 會讓 §13 Test Strategy 額外承載無人值守執行紀律（見 Phase 4）— 缺這資訊就先問，不要預設。
 
 **同時判規格成熟度（路由檢查）**：若 input 已是**凍結的 build spec**（已核可 ADR / 鎖定設計 / AC 可機器檢核）、需求只剩「包成無人值守 agent 可跑的 dispatch」→ **不需要產 PRD**，導去 `goal-engineer` 的 lean build dispatch（其 Frozen Spec Check 把關）。只有 build spec 還需要被**寫出來**（raw input → 決策 → AC）才走本 skill。
+
+**同時判受眾/目的（路由檢查，vs `spec`）**：本 skill 產的是**給 stakeholder 看、要上 wiki 的產品需求文件、停在文件**。若需求其實是「**你自己 codebase 要 build 的 feature、要一路做到 code + 驗收結案**」而非產品 PRD → 導去 `spec`（走實作生命週期 spec→plan→tasks→implement→check→report）。兩者前半都做需求釐清、手感易混——**先問一句「這是給別人看的產品 PRD、還是你自己要 build 的 feature？」把入口岔開**，別預設。
 
 告知 user：「已 load Guideline + 撰寫紀律 + 鎖定執行模式，準備接 raw input」。
 


### PR DESCRIPTION
## 問題
prd-create / spec / adr / prd-breakdown / goal-engineer 共用「訪談→產文件」DNA，個別 description 清楚但缺「並排選哪顆」的指引，連作者都會混（尤其 prd-create vs spec 前半重疊）。

## 改動
- **README.md / README_zh.md**：在「Spec & project」群組後加一個 decision-guide callout（情境→用哪顆表 + prd-create-vs-spec / spec-vs-adr 兩組最易混的一句話拆解 + grill 是共用訪談紀律不是競爭者）。
- **prd-create/SKILL.md**：Phase 1 補一條 vs-`spec` 路由檢查（受眾/目的分流：產品 PRD 停在文件 vs 你自己 codebase 做到 code），版號 0.3.0→0.3.1。沿用既有 goal-engineer 路由的同款分流手法。

## 範圍
只動會混的規劃/文件類 skill，image/telegram/security 等不在混淆區、未動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)