### PR TITLE
Add workflow router and normalize skill metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A collection of AI agent skills that solve real problems — not "summarize this
 
 Grouped by what you're trying to get done — every skill is still a self-contained top-level folder, the grouping is just a map.
 
+### Workflow entrypoint
+
+| Skill | What It Actually Does |
+|-------|----------------------|
+| [workflow-router](workflow-router/) | The front door for the confusing middle: PRD, SD, FR, AC, ADR, tickets, implementation, release, or unattended runs. It asks at most one clarifying question, tells you which specialist skill to use, explains why in plain language, then hands off. It deliberately does not write the PRD/spec/ADR itself |
+
 ### Generate & create
 
 | Skill | What It Actually Does |
@@ -30,7 +36,7 @@ Grouped by what you're trying to get done — every skill is still a self-contai
 | [md2ppt](md2ppt/) | md2pdf's louder sibling. Turn your Markdown report into a presentation-quality .pptx via interactive design dialogue + a reusable Python build script. Generic markdown→pptx tools (Marp, pandoc) produce slides that are syntactically correct but visually broken — md2ppt walks per-slide layout decisions with you, then emits a hand-coded script you can re-run in 5 seconds after content edits. Optional self-check via LibreOffice. Brand template integration via ad-hoc helpers — we tried prescribing a workflow, pulled it back after 5 rounds of "wait that's not the cover layout" |
 | [conference-report](conference-report/) | You went to a conference, recorded the talks, photographed the slides, and came home with a pile of audio, blurry photos, and a vague promise to "write it up someday". This rebuilds faithful per-session notes (slide visuals + speaker transcript, with Whisper hallucinations flagged so you do not quote a robot daydream), then actually asks what report you need -- one talk, a full day, or a multi-day synthesis -- before writing a single word |
 
-### Spec & project
+### Spec & delivery
 
 | Skill | What It Actually Does |
 |-------|----------------------|
@@ -39,27 +45,18 @@ Grouped by what you're trying to get done — every skill is still a self-contai
 | [spec](spec/) | Spec-driven development workflow — from fuzzy idea to verified deliverable. One command, auto-detects project state, walks you through: requirements → review → implement → verify → report. Because "just start coding" is how you end up rewriting everything |
 | [goal-engineer](goal-engineer/) | For when you want an agent to grind on something overnight without you hovering over it. Interview-style, it pins down a goal-driven evaluator-optimizer loop of the generate-and-select kind (generate candidates -> grade against a rubric -> iterate by reason-code -> you pick the winner), then emits a self-contained dispatch doc a fresh session runs blind while you just watch the green/yellow/red pings roll in. It is the upstream *spec author*, not the engine -- hand the dispatch to Claude Code's built-in `/goal`, a headless `claude -p`, or any unattended agent. NOT `/goal` itself, NOT a build-to-spec PRD writer (that's prd-create), NOT a cron timer. One narrow exception: if your build spec is *already frozen* (approved ADR, locked design, machine-checkable AC) and all you're missing is the unattended-run wrapper, it packages a lean build dispatch instead of making you write a full PRD for a decision you already made. Channel-agnostic notifications (Telegram/Discord/Slack/iMessage), and it bakes in a "want an adversarial review before we ship?" gate -- because we got tired of remembering to ask ourselves |
 
-> **Which planning skill do I reach for?** These overlap because they share the same interview-then-document DNA — but they sit at different layers:
->
-> | You have… | Reach for |
-> |---|---|
-> | A pile of notes/requests → a **product requirements doc for others** to read (ships to a wiki) | `prd-create` |
-> | A finished PRD → **Azure DevOps work items** | `prd-breakdown` |
-> | A fuzzy idea *you* will build in your own codebase, **all the way to verified code** | `spec` |
-> | One **hard-to-reverse decision** just made, worth recording *why* | `adr` |
-> | A goal to hand an agent to **grind unattended overnight** | `goal-engineer` |
->
-> The two confused most: **prd-create vs spec** — prd-create writes a product doc *for stakeholders* and stops at the doc; spec walks *your own* build from requirements to verified code. **spec vs adr** — spec is a whole feature's design+build lifecycle; adr is a *single* consequential decision pulled out into its own record (only if it clears the three gates). `grill` isn't a competitor — it's the shared "one question at a time" interview discipline the others reuse.
+> Not sure which one fits? Start with `workflow-router`. The shortest rule of thumb: product requirements go to `prd-create`; repo-local software design / engineering AC / implementation goes to `spec`; one durable technical decision goes to `adr`; approved PRD tickets go to `prd-breakdown`; frozen unattended execution goes to `goal-engineer`.
 
 ### Engineering discipline
 
-> This group's discipline mechanics are adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) — grilling / diagnosing-bugs / domain-modeling — rewritten in Chinese and fitted to this repo's conventions.
+> These are behavior guardrails used before, during, or after the delivery workflows. `grill`, `diagnose`, and `adr` adapt discipline mechanics from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT), rewritten in Chinese and fitted to this repo's conventions.
 
 | Skill | What It Actually Does |
 |-------|----------------------|
 | [grill](grill/) | "Let's discuss first," institutionalized. You drop a fuzzy idea, it refuses to touch code, asks you one question at a time — each with a suggested answer — until shared understanding is confirmed. Its sharpest rule: anything answerable by grep may not be asked. It interrogates the filesystem before it interrogates you. When vocabulary drifts, it also grows a CONTEXT.md glossary for the repo |
 | [diagnose](diagnose/) | Build the lie detector before the interrogation. Until there's one command that reproduces the symptom, no root-cause theory is allowed; and even then you list 3-5 ranked hypotheses with falsifiable predictions before testing the first one. Cures the age-old habit — in AIs and humans — of reading code for two minutes and declaring "found it" |
 | [adr](adr/) | Records architecture decisions, but its first job is talking you out of it. Three gates (hard to reverse / confusing without context / real trade-off) must all pass before it writes anything, and the default format is a title plus three sentences — an ADR's value is in recording *why*, not in filling out a template. It watches for two things especially: deliberate departures from the obvious path, and explicit no's |
+| [prep-repo](prep-repo/) | The "did I forget anything?" checklist before pushing to GitHub. README, commits, secrets, broken links, project structure, tests, CI, Docker, and final cleanup — the stuff you always forget at 2 AM |
 
 ### Research & security
 
@@ -83,7 +80,6 @@ Grouped by what you're trying to get done — every skill is still a self-contai
 | Skill | What It Actually Does |
 |-------|----------------------|
 | [skill-cron](skill-cron/) | One manager to schedule them all. Register any skill for crontab execution + Telegram push — because `claude -p` doesn't support `/skill` syntax, so somebody had to build the bridge. Config in `~/.claude/configs/`, logs auto-rotate, crontab entries self-managed |
-| [prep-repo](prep-repo/) | The "did I forget anything?" checklist before pushing to GitHub. README, commits, secrets, broken links — the stuff you always forget at 2 AM |
 
 ## Installation
 
@@ -109,7 +105,7 @@ Every skill follows a dead-simple convention. If you can write markdown, you can
 
 ```
 skill-name/
-├── SKILL.md          # Frontmatter (name, description, version) + instructions
+├── SKILL.md          # Frontmatter (name, description, version, status, triggers) + instructions
 └── scripts/          # Executable scripts (optional)
     └── script.py
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,6 +14,12 @@
 
 依「你想完成什麼」分組 — 每個 skill 仍是獨立的根目錄資料夾，分組只是張地圖。
 
+### 工作流入口
+
+| Skill | 它到底幹嘛 |
+|-------|----------|
+| [workflow-router](workflow-router/) | 給最容易混的中間地帶當入口：PRD、SD、FR、AC、ADR、拆票、實作、release、無人值守。它最多問一個澄清問題，告訴你該用哪顆 specialist skill，用白話說原因，然後交棒。它刻意不自己寫 PRD/spec/ADR |
+
 ### 生成與創作
 
 | Skill | 它到底幹嘛 |
@@ -30,7 +36,7 @@
 | [md2ppt](md2ppt/) | md2pdf 的吵鬧弟弟。把你的 Markdown 報告變成簡報品質 .pptx，透過互動式設計對話 + 可重用的 Python build script。Generic markdown→pptx 工具（Marp、pandoc）產出來的 slide 技術上對但視覺上爛 — md2ppt 跟你一張一張對話討論 layout，然後吐一份 hand-coded script，內容改動 re-run 5 秒重產。可選 LibreOffice self-check。Brand template 整合走 ad-hoc helpers — 試過 prescribed workflow，5 輪「等等這不是 cover layout」後退掉 |
 | [conference-report](conference-report/) | 你去了場研討會，錄了演講、拍了投影片，回家抱著一堆音檔加糊掉的照片，外帶一句「改天再來整理」的空頭支票。這個 skill 幫你重建忠實的逐場筆記（投影片畫面 + 講者逐字稿，還會標出 Whisper 的幻覺，免得你引用到機器的白日夢），然後在動筆前先問清楚你到底要哪種報告 — 單場、整天、還是跨天綜合 |
 
-### 規格與專案
+### 規格與交付
 
 | Skill | 它到底幹嘛 |
 |-------|----------|
@@ -39,27 +45,18 @@
 | [spec](spec/) | Spec-driven 開發流程 — 從模糊想法到驗收結案。一個指令，自動判斷專案狀態，引導你走完：需求釐清 → 審查 → 實作 → 驗收 → 結案報告。因為「先寫再說」就是你之後要全部重寫的原因 |
 | [goal-engineer](goal-engineer/) | 給那種「想丟給 agent 自己磨一整晚、又不想全程盯著」的場景。它用訪談式問答幫你把一條目標驅動的 evaluator-optimizer loop（generate-and-select 型:產候選 → 依 rubric 評 → 依原因碼迭代 → 你挑最終那個）釘死，吐一份新 session 能 blind 執行的 dispatch 文件，你只要看著紅黃綠燈通知滾進來就好。它是**寫規格的上游、不是引擎** — dispatch 丟給 Claude Code 內建的 `/goal`、headless `claude -p`、或任何無人值守 agent 去跑。不是 `/goal` 本身、不是 build-to-spec 的 PRD 作者（那是 prd-create）、也不是 cron 定時器。唯一窄例外：build spec **已經凍結**（核可的 ADR / 鎖定的設計 / 可機器檢核的 AC）、只差無人值守執行的包裝 → 它直接出一份 lean build dispatch，不會逼你為一個已經拍板的決策回頭寫整份 PRD。通知通道隨你換（Telegram/Discord/Slack/iMessage），而且內建一道「ship 前要不要先對抗審查?」的閘 — 因為我們自己每次都忘記問 |
 
-> **規劃類 skill 該用哪顆？** 它們會像，是因為共用同一套「先訪談再產文件」的 DNA — 但坐在不同樓層：
->
-> | 你手上是… | 用這顆 |
-> |---|---|
-> | 一坨筆記／需求 → 要一份**給別人看的產品需求書**（會上 wiki） | `prd-create` |
-> | 一份完成的 PRD → **Azure DevOps 工作項** | `prd-breakdown` |
-> | 一個模糊想法，**你自己**要在 codebase 裡一路做到**驗收過的 code** | `spec` |
-> | 剛做了一個**難回頭的決策**，值得記下**為什麼** | `adr` |
-> | 一個目標，要丟給 agent **無人值守整晚磨** | `goal-engineer` |
->
-> 最常被搞混的兩組：**prd-create vs spec** — prd-create 寫給 stakeholder 看的產品文件、停在文件；spec 走你自己 codebase 從需求到驗收過的 code。**spec vs adr** — spec 是整個 feature 的設計＋實作生命週期；adr 是其中**單一**關鍵決策抽出來的獨立紀錄（過三重閘才寫）。`grill` 不是競爭者 — 它是其他幾顆共用的「一次問一題」訪談紀律。
+> 不確定用哪顆時，先用 `workflow-router`。最短判斷法：產品需求走 `prd-create`；repo 內的 SD / 工程 AC / 實作走 `spec`；單一重要技術決策走 `adr`；核可 PRD 拆票走 `prd-breakdown`；凍結目標要無人值守跑走 `goal-engineer`。
 
 ### 工程紀律
 
-> 這一組的紀律機制參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的 grilling / diagnosing-bugs / domain-modeling，中文重寫、並調整成本 repo 慣例。
+> 這一組是交付流程前、中、後都會用到的行為護欄。`grill` / `diagnose` / `adr` 的紀律機制參考 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT），中文重寫、並調整成本 repo 慣例。
 
 | Skill | 它到底幹嘛 |
 |-------|----------|
 | [grill](grill/) | 「先討論」的制度化。你丟個模糊想法，它不准自己動手，一次問你一題、每題附建議答案，問到雙方理解一致才放行。最鋒利的一條規則：grep 查得到的事不准問你 — 拷問你之前先拷問 filesystem。詞彙飄了還會順手幫 repo 養一本 CONTEXT.md 詞彙表 |
 | [diagnose](diagnose/) | 先架測謊機，再准審問。沒有一條能重現症狀的指令之前，禁止提任何 root cause 理論；要猜也得一次列 3-5 個假說、附可否證預測、排好序先給你過目。專治 AI（和人類）讀兩眼 code 就宣稱「找到原因了」的老毛病 |
 | [adr](adr/) | 幫你記架構決策，但它的第一件事是勸你別記。三重閘（難回頭 / 沒脈絡會困惑 / 真實取捨）全過才動筆，預設格式是標題加三句話 — ADR 的價值在「記下為什麼」，不在填滿模板。特別會盯兩種東西：刻意偏離顯然路徑的決策、和被否決的方案 |
+| [prep-repo](prep-repo/) | 推上 GitHub 之前的「我是不是忘了什麼」checklist。README、commit、機敏資訊、broken link、專案結構、測試、CI、Docker、最後清理 — 就是那些你凌晨兩點一定會忘的東西 |
 
 ### 研究與安全
 
@@ -83,7 +80,6 @@
 | Skill | 它到底幹嘛 |
 |-------|----------|
 | [skill-cron](skill-cron/) | 一個管理器統治所有排程。註冊任何 skill 做 crontab 定時執行 + Telegram 推播 — 因為 `claude -p` 不支援 `/skill` 語法，總得有人把橋搭起來。設定存 `~/.claude/configs/`，日誌自動輪替，crontab entries 自動管理 |
-| [prep-repo](prep-repo/) | 推上 GitHub 之前的「我是不是忘了什麼」checklist。README、commit、機敏資訊、broken link — 就是那些你凌晨兩點一定會忘的東西 |
 
 ## 安裝
 
@@ -109,7 +105,7 @@ cp -r kc_ai_skills/searxng ~/.openclaw/workspace/skills/
 
 ```
 skill-name/
-├── SKILL.md          # Frontmatter（name, description, version）+ 指令
+├── SKILL.md          # Frontmatter（name, description, version, status, triggers）+ 指令
 └── scripts/          # 可執行腳本（選用）
     └── script.py
 ```
@@ -119,4 +115,3 @@ skill-name/
 - [kc_tradfri_mcp](https://github.com/KerberosClaw/kc_tradfri_mcp) — 「把客廳的燈打開」— 對，我們真的讓 AI 去做這件事了
 - [kc_openclaw_local_llm](https://github.com/KerberosClaw/kc_openclaw_local_llm) — 我們測了 13 個本地 LLM，只有 2 個能穩定呼叫 tool。完整報告在這裡
 ```
-

--- a/character-lora/SKILL.md
+++ b/character-lora/SKILL.md
@@ -2,7 +2,15 @@
 name: character-lora
 description: "Use when the user wants to build a consistent-identity LoRA for an original character — defining the character, generating a face/body-consistent multi-angle dataset (via the gpt-image-gen skill for codex image generation), captioning it, doing base-specific homework, training on a chosen base (Pony / Z-Image / others) on a local GPU, and producing a usable LoRA. This skill ORCHESTRATES the end-to-end pipeline and gates every expensive/irreversible step; it delegates actual image generation to gpt-image-gen and never improvises training settings from memory."
 version: 0.2.1
-triggers: ["/character-lora", "做角色 lora", "訓練角色 lora", "角色 lora 流程", "做一個角色的 lora", "train a character lora", "character lora pipeline"]
+status: mvp
+triggers:
+  - "/character-lora"
+  - "做角色 lora"
+  - "訓練角色 lora"
+  - "角色 lora 流程"
+  - "做一個角色的 lora"
+  - "train a character lora"
+  - "character lora pipeline"
 ---
 
 # character-lora

--- a/conference-report/SKILL.md
+++ b/conference-report/SKILL.md
@@ -2,7 +2,19 @@
 name: conference-report
 description: "Use when the user attended one or more sessions of a conference (with audio recordings + slide photos) and needs help building (1) faithful per-session reconstructions in markdown (slide visuals + speaker transcript with Whisper hallucination annotations), and (2) a downstream report deliverable whose scope and format are decided interactively with the user. Pipeline phase (raw → mlx_whisper Chinese SRT → per-slide multimodal reconstruction → official agenda cross-check via Playwright if available) is deterministic. Report phase is interactive — always quiz user on scope (single-session / single-day / multi-day synthesis), format (existing template / free-form fallback), recipient (formal / informal), and any business workstream mapping before drafting."
 version: 0.2.0
-triggers: ["/conf-report", "處理大會逐字稿", "整理今天 session", "整理今天場次", "conference report", "conf-report", "處理今天的 session", "把今天聽的場次整理成報告", "外訓報告", "大會心得", "大會報告"]
+status: mvp
+triggers:
+  - "/conf-report"
+  - "處理大會逐字稿"
+  - "整理今天 session"
+  - "整理今天場次"
+  - "conference report"
+  - "conf-report"
+  - "處理今天的 session"
+  - "把今天聽的場次整理成報告"
+  - "外訓報告"
+  - "大會心得"
+  - "大會報告"
 ---
 
 # conference-report

--- a/ctf-kit/SKILL.md
+++ b/ctf-kit/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: ctf-kit
-description: "CTF 逆向工程解題工具箱 — 聚焦 Windows 應用程式驗證繞過。從開題偵察到 bypass 驗證的完整流程引導，內建實戰踩坑經驗。"
-version: 0.3.0
-triggers: ["ctf", "reverse", "bypass", "crack", "逆向", "繞過驗證", "破解"]
+description: "Use when the user is solving an authorized CTF / lab reverse-engineering challenge focused on Windows application authentication or license-check bypass. Guides triage → static analysis → dynamic experiment planning → bypass verification, with strong evidence discipline and VM safety boundaries. NOT for real-world unauthorized software cracking, malware deployment, credential theft, or non-Windows CTF domains better handled by a broader CTF skill."
+version: 0.3.1
+status: mvp
+triggers:
+  - "ctf"
+  - "reverse"
+  - "bypass"
+  - "crack"
+  - "逆向"
+  - "繞過驗證"
+  - "破解"
 license: MIT
 compatibility: "Requires filesystem-based agent (Claude Code or similar) with bash, Python 3. Windows dynamic analysis environment (physical or VM) recommended."
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill
@@ -12,6 +20,8 @@ metadata:
 ---
 
 # /ctf-kit — CTF Reverse Engineering Toolkit
+
+You are a Windows CTF reverse-engineering coach. You help the user solve authorized challenge binaries by forcing goal alignment, evidence-first analysis, repeatable experiments, and safe VM-only dynamic testing.
 
 Windows 應用程式驗證繞過的實戰 playbook。
 適用於各種保護殼（VMP、Themida、自製殼等）和驗證方式（網路驗證、本地驗證、混合驗證）。

--- a/docs/skill_writing_patterns.md
+++ b/docs/skill_writing_patterns.md
@@ -62,7 +62,7 @@
 
 ## kc_ai_skills framework 自定 frontmatter 擴充
 
-除了 0x0funky 通用的 `name + description + argument-hint`，kc_ai_skills 自己的 skill loader 多支援兩個欄位（**寫 kc_ai_skills 內的 skill 必加**）：
+除了 0x0funky 通用的 `name + description + argument-hint`，kc_ai_skills 自己的 skill loader 多支援三個欄位（**寫 kc_ai_skills 內的 skill 必加**）：
 
 ### EX1. `version`
 
@@ -73,21 +73,38 @@ version: 0.1.0
 ```
 
 - 用途：skill 變更追蹤、breaking change 判斷
-- `0.x.x` = 還在 iterate 階段，介面可能變
-- `1.0.0+` = stable，breaking change 要 bump major
+- `0.x.x` = `status: experimental` 或 `status: mvp`，還在 iterate 階段，介面可能變
+- `1.0.0+` = `status: stable`，breaking change 要 bump major
 - patch（0.1.0 → 0.1.1）= bug fix / 文案修
 - minor（0.1.0 → 0.2.0）= 新功能不 break 既有
 - major（0.x → 1.0）= breaking 介面變
 
-### EX2. `triggers`
+### EX2. `status`
+
+成熟度標記（必填）：
+
+```yaml
+status: mvp
+```
+
+- `experimental` = 還在摸索，入口/流程可能大改，只適合早期試用
+- `mvp` = 可用，但仍在調整；version 應維持 `0.x.x`
+- `stable` = 常用且成熟；version 應為 `1.0.0+`，破壞既有用法要 bump major
+- 不要用 `status` 取代 version：status 說「穩定度」，version 說「變更序列」
+
+### EX3. `triggers`
 
 Explicit trigger pattern list（指令觸發 + 自然語言觸發都可）：
 
 ```yaml
-triggers: ["/llm-wiki-lint", "wiki lint", "掃 wiki"]
+triggers:
+  - "/llm-wiki-lint"
+  - "wiki lint"
+  - "掃 wiki"
 ```
 
 - 用途：補強 description 的 trigger 判斷，命中任一觸發詞 = 啟用 skill
+- canonical 格式 = YAML block list（每個 trigger 一行），不要用 inline array
 - **中文指令式**（「掃 wiki」「整理 memory」「投履歷前查公司」）特別需要 explicit list — 因為自然中文沒有 standardize trigger phrase
 - 跟 description 不衝突 — description 寫**情境**（「Use when ...」），triggers 列**字面觸發詞**
 - slash command 形式（`/skill-name`）也要列進來
@@ -95,7 +112,7 @@ triggers: ["/llm-wiki-lint", "wiki lint", "掃 wiki"]
 ### 為什麼 0x0funky 沒這兩個
 
 - 0x0funky 的 skill 跑在 Codex / Claude Code 原生 skill loader，那邊用 `description` + `argument-hint` 就夠（英文 trigger 自然包在 description 裡）
-- kc_ai_skills 是**自有 skill loader**，要支援中文 trigger + 版本管理，故擴充
+- kc_ai_skills 是**自有 skill loader**，要支援中文 trigger + 版本管理 + 成熟度標記，故擴充
 - **互不衝突，並存使用** — 套 0x0funky patterns 不會把這兩欄位拿掉
 
 ---
@@ -233,7 +250,8 @@ skill 寫完、**release 前主動問 user 要不要對抗審查**（不要等 u
 
 [kc_ai_skills 自定擴充（寫 kc_ai_skills 內 skill 必加）]
 - [ ] frontmatter `version` 欄位（semver，初版 0.1.0）
-- [ ] frontmatter `triggers` 欄位（含 slash command + 中文自然語言觸發詞）
+- [ ] frontmatter `status` 欄位（experimental / mvp / stable，且與 version 對齊）
+- [ ] frontmatter `triggers` 欄位（block list，含 slash command + 中文自然語言觸發詞）
 
 [高頻推薦]
 - [ ] 重要事項用 **CRITICAL** / **MANDATORY** 標記

--- a/goal-engineer/SKILL.md
+++ b/goal-engineer/SKILL.md
@@ -1,8 +1,21 @@
 ---
 name: goal-engineer
 description: "Use when the user wants to AUTHOR an unattended dispatch for either: (1) a goal-driven evaluator-optimizer loop of the GENERATE-AND-SELECT kind (generate candidates → grade against a rubric → iterate by reason-code → keep the best; the human picks the final selection), or (2) a lean build-to-spec run whose build spec is ALREADY FROZEN (approved ADR / locked design / accepted machine-checkable AC) and the only missing piece is the unattended-execution wrapper. A fresh-session agent runs the dispatch hands-off while the human only watches traffic-light push notifications. Interview-style forcing questions lock the spec, then it emits a self-contained dispatch markdown + a channel-agnostic notification protocol. This is the upstream SPEC AUTHOR, NOT a runtime: the dispatch is run by Claude Code's /goal, a headless `-p` session, or any unattended agent — /goal is the engine, this writes what you feed it. It NEVER authors build specs, product decisions, or AC — creating a build spec / PRD from raw input is prd-create. NOT a time scheduler (/loop or cron), NOT a recurring-push registrar (skill-cron)."
-version: 0.4.0
-triggers: ["/goal-engineer", "goal engineering", "goal engineer", "設計無人值守 loop", "固化 goal-loop", "unattended loop", "evaluator-optimizer loop", "generate-and-select loop", "dispatch 換手文件", "lean build dispatch", "凍結規格包 dispatch", "frozen spec dispatch"]
+version: 1.0.0
+status: stable
+triggers:
+  - "/goal-engineer"
+  - "goal engineering"
+  - "goal engineer"
+  - "設計無人值守 loop"
+  - "固化 goal-loop"
+  - "unattended loop"
+  - "evaluator-optimizer loop"
+  - "generate-and-select loop"
+  - "dispatch 換手文件"
+  - "lean build dispatch"
+  - "凍結規格包 dispatch"
+  - "frozen spec dispatch"
 ---
 
 # /goal-engineer — Unattended Goal-Loop Dispatch Architect

--- a/gpt-image-gen/SKILL.md
+++ b/gpt-image-gen/SKILL.md
@@ -2,6 +2,7 @@
 name: gpt-image-gen
 description: "Use when the user asks to generate an image via GPT/Codex (e.g. 「叫 gpt 生圖」「幫我用 gpt 生圖」「gpt 畫一個 X」). The skill drafts a Chinese + English prompt pair, iterates with the user until they explicitly approve, then dispatches Codex CLI ($imagegen skill, codex built-in image_gen) in the background, monitors progress, converts the result to a jpg in the current working directory, and writes a sidecar prompt log. Does text-to-image AND img2img — drop a reference image (on-disk file) and it runs Codex `-i` to lock a face/character across scenes."
 version: 0.4.0
+status: mvp
 triggers:
   - "叫 gpt 生圖"
   - "叫gpt生圖"

--- a/job-scout/SKILL.md
+++ b/job-scout/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: job-scout
-description: "求職前公司與職位篩選工具。當使用者提到想投履歷、考慮某公司、評估某職缺、或想了解某公司值不值得去時觸發。輸入公司名稱（必要）+ 職位名稱（選填），輸出綜合評估與建議。"
-version: 1.0.0
-triggers: ["/job-scout", "查公司", "評估職缺", "這間公司如何", "投履歷前查"]
+description: "Use when the user is considering applying to, interviewing with, or accepting an offer from a company and wants due diligence on the company and optionally a specific role. Requires a company name, optionally a job title, then researches current public data, employee reviews, salary signals, product/tech quality, and red flags before giving a grounded recommendation. NOT for generic career coaching or resume editing."
+version: 1.0.1
+status: stable
+triggers:
+  - "/job-scout"
+  - "查公司"
+  - "評估職缺"
+  - "這間公司如何"
+  - "投履歷前查"
 ---
 
 # Job Scout — 求職篩選與公司調查
+
+You are a job-market due-diligence analyst. Your job is to help the user avoid bad applications and bad offers by verifying current public signals, separating evidence from inference, and clearly calling out uncertainty.
 
 ## 使用方式
 
@@ -26,6 +34,12 @@ triggers: ["/job-scout", "查公司", "評估職缺", "這間公司如何", "投
 1. **公司名稱**為必要參數。如果使用者沒有提供，直接詢問公司名稱，不要猜測或開始調查。
 2. **職位名稱**為選填參數。如果使用者沒有提供，先詢問一次：「請問想評估的職位是？（直接按 Enter 跳過）」。使用者仍未提供才跳過 Phase 4（職位行情分析）。
 3. 確認參數齊全後才開始調查流程。
+
+## 不適用
+
+- 不改履歷、不寫 cover letter、不模擬面試。
+- 不替 user 做最後職涯決定；只提供風險、機會與建議。
+- 不把單一匿名評論當成事實；負面訊號要交叉查證。
 
 ---
 

--- a/llm-benchmark/SKILL.md
+++ b/llm-benchmark/SKILL.md
@@ -1,13 +1,26 @@
 ---
 name: llm-benchmark
-description: "本地 LLM Benchmark 工具。當使用者想測試、比較或選擇本地 Ollama 模型時觸發。流程：檢查 Ollama 安裝 → 依 VRAM 推薦模型大小 → 下載模型 → 跑 benchmark → 與現有模型比較 → 輸出 markdown 報告。"
-version: 1.0.0
-triggers: ["/llm-benchmark", "測本地模型", "模型 benchmark", "比較 ollama 模型"]
+description: "Use when the user wants to test, compare, or choose local Ollama models for their machine. Checks Ollama/GPU state, recommends model sizes from available VRAM, preserves existing benchmark records, pulls only approved models, runs repeatable benchmarks, restores stopped services, and writes a markdown comparison report. NOT for hosted API model evaluation or subjective chat-quality judging without local benchmark commands."
+version: 1.0.1
+status: stable
+triggers:
+  - "/llm-benchmark"
+  - "測本地模型"
+  - "模型 benchmark"
+  - "比較 ollama 模型"
 ---
 
 # LLM Benchmark Skill
 
-你是本地 LLM 效能評測專家。執行以下完整流程：
+You are a local LLM benchmarking specialist. 你負責用可重現的命令測 Ollama 模型效能，保護使用者現有服務狀態，並把推薦和限制講清楚。
+
+## 不適用
+
+- 不評測雲端 API 模型。
+- 不用單次主觀聊天感覺取代 benchmark。
+- 不在未確認硬體與服務狀態前直接 pull 大模型或重啟服務。
+
+執行以下完整流程：
 
 ## Step 0：環境檢查
 

--- a/llm-wiki-lint/SKILL.md
+++ b/llm-wiki-lint/SKILL.md
@@ -2,7 +2,13 @@
 name: llm-wiki-lint
 description: "Use when the user wants to lint a repo following the Karpathy LLM Wiki pattern (raw/ + wiki/ + SCHEMA.md / index.md / log.md). The skill detects path, scans wiki pages + schema layer, reports frontmatter gaps, broken in-body links, source traceability breaks, stale claims, orphan pages, index synopsis contradictions, and SCHEMA-vs-reality drift. Phase 1 is read-only report; Phase 2 (fix + log.md LINT entry) only runs after the user explicitly approves."
 version: 0.3.1
-triggers: ["/llm-wiki-lint", "llm wiki lint", "wiki lint", "掃 wiki", "wiki 健檢"]
+status: mvp
+triggers:
+  - "/llm-wiki-lint"
+  - "llm wiki lint"
+  - "wiki lint"
+  - "掃 wiki"
+  - "wiki 健檢"
 argument-hint: "[path]"
 ---
 

--- a/md2pdf/SKILL.md
+++ b/md2pdf/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: md2pdf
-description: "Convert Markdown to publication-ready A4 PDF with automatic ASCII-to-Mermaid conversion, CJK font handling, and self-check. Use when user says '/md2pdf', 'convert to pdf', 'markdown to pdf', or similar."
-version: 0.1.0
-triggers: ["/md2pdf", "轉 pdf", "markdown 轉 pdf", "convert to pdf"]
+description: "Use when the user wants to convert one Markdown file into a publication-ready A4 PDF, especially when the source may contain Mermaid diagrams, ASCII diagrams, CJK text, tables, or pandoc/weasyprint edge cases. Works by copying the source to a _pdf.md working file, converting diagrams, escaping PDF-breaking syntax, rendering with pandoc + weasyprint, then self-checking pages. NOT for batch conversion, slide decks, or editing the original Markdown in place."
+version: 1.0.0
+status: stable
+triggers:
+  - "/md2pdf"
+  - "轉 pdf"
+  - "markdown 轉 pdf"
+  - "convert to pdf"
 ---
 
 # md2pdf
 
-Convert a Markdown file to a clean, publication-ready A4 PDF.
+You are a Markdown-to-PDF production assistant. You convert exactly one Markdown file at a time into a clean, publication-ready A4 PDF while preserving the original source file.
 
 ## Trigger
 

--- a/md2ppt/SKILL.md
+++ b/md2ppt/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: md2ppt
-description: "Convert a Markdown report into a presentation-quality .pptx via interactive design decisions + hand-coded build script. Use when user says '/md2ppt', 'markdown to pptx', 'make slides from this md', '簡報', '做投影片', or similar. Optional self-check loop: if LibreOffice available, renders pptx → PNG per slide and checks for overflow / tiny font / emoji / misaligned content before user review. NOT a generic auto-converter — drives a per-slide layout dialogue then emits a reusable build script. Brand-template integration is supported as ad-hoc primitives (helpers exist) but is intentionally not a prescribed workflow — every brand template differs and is best handled by direct LLM-user dialogue."
-version: 0.4.0
-triggers: ["/md2ppt", "markdown to pptx", "md to pptx", "make slides", "簡報", "做投影片", "pptx 生成"]
+description: "Use when the user wants to turn a Markdown report into a presentation-quality .pptx via interactive design decisions and a reusable hand-coded build script. Drives pre-analysis, global style choices, optional per-slide layout dialogue, python-pptx composition, and optional LibreOffice render self-check. NOT a generic auto-converter, NOT for PDF output, and NOT a fixed brand-template pipeline — brand integration is handled ad hoc through helper primitives."
+version: 0.4.1
+status: mvp
+triggers:
+  - "/md2ppt"
+  - "markdown to pptx"
+  - "md to pptx"
+  - "make slides"
+  - "簡報"
+  - "做投影片"
+  - "pptx 生成"
 argument-hint: '<input.md> [<output.pptx>]'
 ---
 

--- a/memory-lint/SKILL.md
+++ b/memory-lint/SKILL.md
@@ -2,7 +2,12 @@
 name: memory-lint
 description: "Use when the user wants to lint a Claude Code memory directory (~/.claude/memory or custom path) for index inconsistency, stale project state, duplicate / conflicting feedback rules, naming convention violations, frontmatter gaps, and oversized files. The skill detects path, scans root-level *.md, reports findings by severity. Read-only — never auto-fixes, never deletes, never merges."
 version: 0.2.0
-triggers: ["/memory-lint", "memory lint", "掃 memory", "memory 健檢"]
+status: mvp
+triggers:
+  - "/memory-lint"
+  - "memory lint"
+  - "掃 memory"
+  - "memory 健檢"
 argument-hint: "[path]"
 ---
 

--- a/prep-repo/SKILL.md
+++ b/prep-repo/SKILL.md
@@ -1,13 +1,31 @@
 ---
 name: prep-repo
-description: "Prepare a project for GitHub: README, commit conventions, sensitive data scan, broken link check, project structure, tests, CI, Docker, and final cleanup."
-version: 2.0.0
-triggers: ["/prep-repo", "推上 GitHub 前檢查", "開源前體檢", "prepare repo"]
+description: "Use when the user wants to prepare a local project for GitHub or public release. Runs a release-readiness sweep over README structure, bilingual docs, commit hygiene, sensitive-data exposure, broken links, markdown rendering, project layout, tests, CI, Docker, and final cleanup. Fixes issues only inside the target repo and treats secrets/history rewriting as explicit high-risk gates. NOT for publishing without user approval or for private operational runbooks that should not be open-sourced."
+version: 2.0.1
+status: stable
+triggers:
+  - "/prep-repo"
+  - "推上 GitHub 前檢查"
+  - "開源前體檢"
+  - "prepare repo"
 ---
 
 # Prep Repo
 
+You are a release-readiness auditor for public GitHub projects. You scan first, separate must-fix blockers from polish, and never let private data, broken docs, or misleading setup instructions slip into a public repo.
+
 Prepare a local project for publishing to GitHub. Run through all checks and fix issues found.
+
+## 不適用
+
+- 不直接 publish、push、改 repo visibility，除非 user 明確要求。
+- 不自動重寫 git history；若掃到歷史中的秘密，先停下說明風險與命令。
+- 不把 private/internal 專案硬改成 public 文案；先確認目標 visibility。
+
+## 跟工程流程 skill 的關係
+
+- `spec` / `prd-create` / `prd-breakdown` / `goal-engineer` 管「要做什麼、怎麼做、怎麼交給 agent 或 ADO」；本 skill 只管**做完後能不能安全公開/推 GitHub**。
+- 遇到 bug 用 `diagnose`，遇到尚未定義的 feature 用 `spec`，遇到已完成但準備 release 的 repo 才用本 skill。
 
 ## Checklist
 

--- a/repo-scan/SKILL.md
+++ b/repo-scan/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: repo-scan
-description: "GitHub 開源專案安全掃描工具。輸入 GitHub repo URL，輸出專案概覽、靜態弱點分析、供應鏈風險、Issues 安全回報、維護者評估與風險總結。適用於安裝前的安全評估。"
-version: 1.0.0
-triggers: ["/repo-scan", "掃這個 repo", "安裝前掃描", "repo 安全掃描"]
+description: "Use when the user wants to evaluate a GitHub repository before installing, running, forking, or depending on it. Takes a GitHub repo URL, cleans tracking params, shallow-clones to /tmp, inspects dependency/supply-chain risk, static vulnerability patterns, issue-reported security problems, maintainer health, and produces a risk summary. NOT for reviewing the user's own PR diff or for running untrusted code."
+version: 1.0.1
+status: stable
+triggers:
+  - "/repo-scan"
+  - "掃這個 repo"
+  - "安裝前掃描"
+  - "repo 安全掃描"
 ---
 
 # Repo Scan — GitHub 開源專案安全掃描
+
+You are a supply-chain security reviewer for open-source GitHub repositories. Your job is to help the user decide whether a repo is safe enough to install or depend on without executing its code.
 
 ## 使用方式
 
@@ -24,6 +31,12 @@ triggers: ["/repo-scan", "掃這個 repo", "安裝前掃描", "repo 安全掃描
 2. URL 清理：移除 `?fbclid=`、`?ref=` 等追蹤參數，保留 `https://github.com/owner/repo` 格式。
 3. 前置檢查通過後才開始掃描流程。
 4. 掃描完成後清理：刪除 clone 到 `/tmp/` 的 repo。
+
+## 不適用
+
+- 不執行 clone 下來的專案、不跑 install scripts、不啟動服務。
+- 不取代 PR security review；這是安裝前第三方 repo 風險評估。
+- 不把 star 數或 README 宣稱當作安全證據。
 
 ---
 

--- a/rewrite-tone/SKILL.md
+++ b/rewrite-tone/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: rewrite-tone
-description: "Rewrite Markdown files with a conversational, humorous, self-deprecating tone. Turns dry technical docs into engaging war stories. Use when user says 'rewrite', 'change tone', 'make it fun', or similar."
-version: 1.0.0
-triggers: ["/rewrite-tone", "改寫語氣", "rewrite tone", "寫得好玩點"]
+description: "Use when the user wants to rewrite Markdown prose into a conversational, humorous, self-deprecating engineering tone while preserving technical accuracy and document structure. Rewrites prose sections only, keeps code blocks, diagrams, tables, English summary blocks, and factual claims intact. NOT for changing requirements, adding new technical content, or editing non-Markdown artifacts."
+version: 1.0.1
+status: stable
+triggers:
+  - "/rewrite-tone"
+  - "改寫語氣"
+  - "rewrite tone"
+  - "寫得好玩點"
 ---
 
 # Rewrite Tone
 
-Rewrite the specified Markdown file(s) with a conversational, humorous, self-deprecating engineering tone.
+You are a technical editor with a conversational engineering voice. You make dry Markdown easier to read without changing the facts, structure, code, diagrams, or tables.
 
 ## Tone Guidelines
 

--- a/searxng/SKILL.md
+++ b/searxng/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: searxng
-description: Privacy-respecting metasearch using your local SearXNG instance. Search the web, images, news, and more without external API dependencies.
+description: "Use when the user wants privacy-respecting web, image, news, or video search through a configured local SearXNG instance instead of external search APIs. Calls the bundled script against SEARXNG_URL, supports result limits/categories/language/time range, and can return human-readable or JSON output. NOT for searches when no SearXNG instance is configured or when authenticated/private data retrieval is required."
 author: Avinash Venkatswamy
-version: 1.0.1
+version: 1.0.2
+status: stable
 homepage: https://searxng.org
 triggers:
   - "search for"
@@ -14,7 +15,15 @@ metadata: {"clawdbot":{"emoji":"🔍","requires":{"bins":["python3"]},"config":{
 
 # SearXNG Search
 
+You are a privacy-preserving search operator. You route search requests through the user's configured SearXNG instance and report results without introducing third-party API dependencies.
+
 Search the web using your local SearXNG instance - a privacy-respecting metasearch engine.
+
+## Not For
+
+- Do not use if `SEARXNG_URL` is missing and no local/default instance is reachable.
+- Do not scrape authenticated pages or private user accounts.
+- Do not treat search snippets as verified facts; cite uncertainty and follow sources when needed.
 
 ## Commands
 
@@ -59,11 +68,11 @@ Default (if not set): `http://localhost:8080`
 
 ## Features
 
-- 🔒 Privacy-focused (uses your local instance)
-- 🌐 Multi-engine aggregation
-- 📰 Multiple search categories
-- 🎨 Rich formatted output
-- 🚀 Fast JSON mode for programmatic use
+- Privacy-focused (uses your local instance)
+- Multi-engine aggregation
+- Multiple search categories
+- Rich formatted output
+- Fast JSON mode for programmatic use
 
 ## API
 

--- a/skill-cron/SKILL.md
+++ b/skill-cron/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: skill-cron
-description: "排程推播管理器 — 註冊/管理需定時執行並推送 Telegram 通知的 skill。Use when user says '/skill-cron', '排程', '定時執行', 'crontab', 'telegram 通知' or similar."
-version: 0.2.0
-triggers: ["/skill-cron", "排程", "定時執行", "crontab", "telegram 通知"]
+description: "Use when the user wants to register, inspect, manually run, or remove scheduled Claude skills with Telegram push notifications. Presents a menu, discovers schedulable skills with headless-prompt frontmatter, converts natural-language schedules into cron entries with conflict confirmation, writes managed config, and verifies notification delivery. NOT for one-off task execution without scheduling or for running skills that lack a headless prompt."
+version: 0.2.1
+status: mvp
+triggers:
+  - "/skill-cron"
+  - "排程"
+  - "定時執行"
+  - "crontab"
+  - "telegram 通知"
 ---
 
 # skill-cron
 
+You are a scheduled-skill operations manager. You translate the user's scheduling intent into explicit cron-managed jobs, verify notification plumbing, and keep every automated command inspectable.
+
 統一管理需要定時執行 + Telegram 推播的 skill。
+
+## 不適用
+
+- 不替沒有 `headless-prompt` 的 skill 硬排程；先要求補 frontmatter。
+- 不把模糊或互相衝突的時間描述自行猜成 cron。
+- 不存取或輸出 Telegram token 內容；只驗證設定是否存在與可用。
 
 ## Trigger
 

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: spec
-description: "Spec-driven 開發流程 — 從模糊需求到驗收結案。自動判斷專案狀態，引導 user 走完：需求釐清 → 技術審查 → 實作 → 驗收 → 結案報告。"
-version: 1.3.0
-triggers: ["spec", "開 spec", "建 spec", "新功能"]
+description: "Use when the user wants a spec-driven development workflow for implementing a feature in the current codebase, from fuzzy idea or existing active spec through requirements, technical plan, tasks, implementation, verification, and closure report. Auto-detects project/spec state, writes persistent files under specs/, asks one grounded question at a time when requirements are ambiguous, and stops at stage gates. NOT for stakeholder PRDs (prd-create), ADO ticket breakdown (prd-breakdown), single architecture-decision records (adr), or already-frozen tasks that should simply be implemented."
+version: 1.3.1
+status: stable
+triggers:
+  - "spec"
+  - "開 spec"
+  - "建 spec"
+  - "新功能"
 ---
 
 # /spec — Spec-Driven Development
+
+You are a spec-driven development lead. You turn a user feature request into persistent requirements, implementation plan, task checklist, verified code, and a closure report while respecting the current repository state.
 
 把「實作 feature 的流程」標準化：需求釐清 → 技術審查 → 實作 → 驗收 → 結案。
 一個入口，自動判斷該做什麼。
@@ -491,6 +498,18 @@ triggers: ["spec", "開 spec", "建 spec", "新功能"]
 ```
 
 **為什麼分 active/completed？** 一眼看到還剩幾個 active，completed 歸檔不擋視野。靈感來自 OpenAI 的 `docs/exec-plans/{active,completed}/` 慣例（harness-engineering 文章）。
+
+---
+
+## 跟其他工程流程 skill 的關係
+
+- **`grill`**：只做「先討論、對齊理解」，不產 spec/plan/tasks、不實作。需求還在霧裡、user 明確說先討論 → 先用 `grill`；一旦要落成可執行開發流程 → 回到本 skill。
+- **`diagnose`**：處理已經壞掉的軟體。症狀是 bug/crash/錯誤輸出/flaky → 先用 `diagnose` 建 reproduction 和假說，不要開新 spec 假裝是 feature。
+- **`prd-create`**：寫給 stakeholder 的產品需求文件，停在 PRD/wiki。若目標是「給別人看的產品規格」→ `prd-create`；若目標是「我在這個 repo 把 feature 做完並驗收」→ 本 skill。
+- **`prd-breakdown`**：把已核可 PRD 拆成 Azure DevOps tickets。本 skill 的 `tasks.md` 是本地開發 checklist，不負責推 ADO。
+- **`goal-engineer`**：把已凍結的目標/規格包成無人值守 dispatch。若規格還需要釐清或 code 還要在當前 repo 實作 → 本 skill；若規格已鎖，只差交給 agent blind run → `goal-engineer`。
+- **`adr`**：記錄單一難回頭決策的「為什麼」。本 skill 可以產生需要 ADR 的決策，但不要把 ADR 寫成 spec，也不要把整個 feature lifecycle 塞進 ADR。
+- **`prep-repo`**：發布前總檢查。功能已做完、要公開或推 GitHub 前 → `prep-repo`；不要用它取代 spec 的需求/實作/驗收流程。
 
 ---
 

--- a/workflow-router/SKILL.md
+++ b/workflow-router/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: workflow-router
+description: "Use when the user is unsure which kc_ai_skills workflow skill to use, or describes work involving PRD, SD/software design, FR, AC/acceptance criteria, ADR, tickets, implementation, debugging, release checks, or unattended agent execution. Triage the request with at most one clarifying question when needed, explain the route in plain language, then hand off to the right specialist skill. This is an entry router only: it does not write PRDs, specs, ADRs, tickets, or dispatches itself."
+version: 0.1.0
+status: mvp
+triggers:
+  - "/workflow-router"
+  - "/workflow"
+  - "我該用哪個 skill"
+  - "要用哪個 skill"
+  - "PRD SD FR AC ADR"
+  - "流程怎麼走"
+  - "幫我判斷用哪顆"
+---
+
+# workflow-router — 工程流程入口分流
+
+You are a workflow triage router. Your job is to identify what the user is trying to do, choose the right kc_ai_skills workflow skill, explain the choice in plain language, and hand off. You are not the downstream specialist.
+
+## Step 1: Classify the user's current object
+
+First decide what the user is holding right now:
+
+| User has / asks for | Route to | Plain meaning |
+|---|---|---|
+| "先討論", fuzzy idea, unclear scope, no files yet | `grill` | Align first; do not write deliverables yet |
+| Bug, crash, wrong output, flaky behavior | `diagnose` | Reproduce first, then test hypotheses |
+| Raw notes, meeting transcript, product request, FR/product AC not settled | `prd-create` | Write or revise stakeholder-facing PRD |
+| Finished PRD that needs ADO work items | `prd-breakdown` | Convert approved PRD into vertical-slice tickets |
+| Software design / SD, engineering AC, implementation plan, tasks, code verification | `spec` | Turn requirements into repo-local design, plan, tasks, implementation, check, report |
+| One hard-to-reverse technical decision and the reason why | `adr` | Record the decision if it passes the ADR gates |
+| Frozen spec/goal with machine-checkable AC that should run unattended | `goal-engineer` | Package a blind-runnable agent dispatch; do not invent requirements |
+| Finished repo/docs before public release or GitHub push | `prep-repo` | Release-readiness and leak/link/docs hygiene |
+
+## Step 2: Ask at most one clarifying question
+
+If the route is obvious, do not ask. State the route and why.
+
+If ambiguous, ask exactly one multiple-choice-style question in prose, with your recommended default first:
+
+```text
+你現在主要要做哪件事？
+1. 落技術設計/工程驗收/實作計畫（建議：spec）
+2. 改產品需求/FR/產品驗收條件（prd-create）
+3. 記一個架構決策（adr）
+```
+
+Common ambiguity rules:
+
+- PRD exists + user wants SD / software design / engineering AC / implementation breakdown → `spec`.
+- PRD exists + product behavior, FR, stakeholder AC changed → update PRD with `prd-create`, then optionally `prd-breakdown`.
+- PRD or spec exists + only one durable architecture choice needs rationale → `adr`.
+- PRD/spec/AC are frozen + user wants agent to run overnight / hands-off → `goal-engineer`.
+- User says "AC" without context → ask whether they mean product acceptance or engineering verification.
+- User says "FR" → default to `prd-create` unless they explicitly ask for engineering implementation details.
+
+## Step 3: Hand off cleanly
+
+Output a short route decision:
+
+```text
+用 `spec`。
+原因：你已有 PRD，現在要落 SD / 工程 AC / 實作拆分；這是 repo-local 技術設計與驗收，不是改產品 PRD。
+
+下一步可以這樣開：
+/spec <一句話描述要落地的功能或變更>
+```
+
+If the environment supports invoking the target skill directly, proceed with that skill after the route decision. If not, give the exact command or phrasing the user should use.
+
+## Anti-patterns
+
+- ❌ 自己開始寫 PRD / spec / ADR / ticket — router 只分流。
+- ❌ 問一整份問卷 — 最多一個澄清問題。
+- ❌ 看到 "PRD" 就一律 `prd-create` — 有 PRD 但要落技術設計時是 `spec`。
+- ❌ 看到 "decision" 就一律 `adr` — 只有難回頭、有脈絡價值、有取捨的決策才 ADR。
+- ❌ 把 `goal-engineer` 當成需求釐清工具 — 它只包已凍結目標的無人值守執行。
+
+## Important rules
+
+1. **Route, don't do.** 本 skill 是入口，不是下游工作者。
+2. **One question max.** 不清楚才問，而且只問最能分流的一題。
+3. **PRD / SD / FR / AC 用白話翻譯。** FR = 功能需求；AC = 驗收條件；SD = 軟體/系統設計。
+4. **產品層走 PRD，工程層走 spec，決策紀錄走 ADR，無人值守走 goal-engineer。**
+5. **Always explain the route in one sentence** so the user learns the map over time.


### PR DESCRIPTION
## Summary
- Add workflow-router as a thin entrypoint for PRD / SD / FR / AC / ADR / ticket / implementation routing
- Normalize skill frontmatter with required status and block-list triggers
- Clarify version/status policy and README skill grouping

## Validation
- ruby frontmatter policy check
- git diff --cached --check