### PR TITLE
lint sweep: 補 anti-patterns/Important rules + 對稱 routing 指路

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,44 +1,29 @@
 # HANDOFF — kc_ai_skills 維護接手
 
-> 給接手繼續整理這個 repo 的 agent。讀這份就知道現況＋下一步（lint sweep）＋紅線。
-> 建立：2026-07-15。
+> 給接手繼續整理這個 repo 的 agent。讀這份就知道現況＋剩餘工項＋紅線。
+> 建立：2026-07-15；更新：2026-07-30（frontmatter 一致性 + 第二輪 pattern lint 已收）。
 
 ## 現況
-- 22 顆 skill、public、MIT、雙語 README（`README.md` + `README_zh.md`）。
-- 剛併入 #21：README 加了「規劃類 skill 選哪顆」決策框、prd-create 補 vs-spec 路由（版號 0.3.1）。
+
+- 24 顆 skill、public、MIT、雙語 README（`README.md` + `README_zh.md`）。
+- **Frontmatter 已全數一致**（原 handoff 的三個待辦已於 #23 收）：24 顆全有 `version` / `status` / `triggers`；triggers 全為 YAML block list；status↔version 語意對齊（`stable` = 1.0+、`mvp` = 0.x）。
+- **第二輪 pattern lint 已收**：補齊 anti-patterns / Important rules 缺口（ctf-kit / job-scout / llm-benchmark / repo-scan / skill-cron / prep-repo / spec / md2pdf），補對稱 routing 指路（rewrite-tone↔rewrite-tw、adr、diagnose）。
 - adr / diagnose / grill 三顆從 mattpocock/skills 內化重寫，是這批的 canonical 範本。
 
-## 任務：lint sweep（frontmatter 一致性 + pattern 檢核）
+## 剩餘工項（判斷後刻意不做的，接手者要動再評估）
 
-lint 依據＝`docs/skill_writing_patterns.md`（15 patterns + checklist）。把 22 顆逐一對照。
-
-### 已驗證的 frontmatter 不一致（全 22 顆掃過、非抽樣外推）
-- 🔴 **`status:` 欄大量缺**：只有 adr / diagnose / grill / prd-create ＝ mvp、prd-breakdown ＝ stable，其餘約 17 顆**沒有 status 欄**。先跟 user 定「status 是否必填、值域（mvp / stable / …）」，再補齊。
-- 🟠 **triggers 格式混用**：有的 YAML list（`- "x"`）、有的 inline array（`["x","y"]`）。挑一種當 canonical、統一。
-- 🟠 **version 語意未定義**：0.1.0～2.0.0 都有，有 mvp 卻掛 1.0.0、也有 0.x。定清楚「status（mvp/stable）↔ version 號」的對應規則。
-
-### 從深讀 prd-create / spec / adr 看到的較深缺口（其餘 19 顆待同樣檢查）
-- **description 深度不一**：prd-create 的 description 很長、帶 NOT-for 路由；spec 只有一行。統一「description 要不要帶 trigger／路由資訊」。
-- **「跟其他 skill 的關係」段落有的有、有的沒**：prd-create 有完整 relations 段、spec 幾乎沒有。有了 #21 決策框後，易混的 skill 應在自己 SKILL.md 補一行「vs X 見 routing guide」（agent 只 load SKILL.md 時看不到 README 表）。
-- **grill canonical 引用**：prd-create / spec 都正確指「訪談問法紀律同 grill」。掃其他做訪談的 skill 是否一致指 grill、而非各自重寫。
+- **大單體是否拆 `references/`**：`gpt-image-gen`（25KB）、`conference-report`（23KB）、`spec`（21KB）、`md2ppt`（20KB）、`prd-create`（19KB）、`ctf-kit`（19KB）皆 > 5KB。但 checklist 的判準是「> 5KB **且有進階/少用段落**才拆、緊湊單體可豁免」——這幾顆多為前後相依的單一流程文件，硬拆會傷可讀性。**逐顆判斷、非無腦全拆**；ctf-kit 已把細節外放到 `docs/`（vmp-guide 等）、主檔留骨架，是可參考的折衷。
+- **`md2ppt` 寫死絕對路徑**（`~/.venv_pptx`、`~/.claude/skills/md2ppt/...`）：public repo 可攜性差，但改動牽動同目錄多支 script 的 import，屬需要一起驗的重構、未在本輪動。對照 `skill-cron` 用 `${CLAUDE_SKILL_DIR}` 的寫法作為目標型態。
+- **description 深度一致性**：多數已帶 NOT-for 路由，少數（rewrite-tone 等薄工具）仍是一行——薄殼可接受，不強制拉長。
 
 ## 已經好的（別動壞）
-- #21 的決策框、mattpocock 出處標註（Acknowledgments／README 工程紀律段的 attribution）——別砍。
+
+- #21 的規劃類 skill 決策框、mattpocock 出處標註（Acknowledgments／README 工程紀律段的 attribution）——別砍。
 - adr / diagnose / grill 是範本，其他對齊它們、不是反過來。
 
 ## 紅線
+
 - 🔴 **public repo**：範例／fixtures 一律抽象、虛構——**禁真公司／客戶／內部 ticket／真人**（見 memory `feedback_public_skill_examples`）。寫前寫後各 grep 一次禁用詞。
 - 🔴 **PR-driven**：branch + PR、不直接 push main（此 repo commit 尾帶 `(#N)`）。
 - 🔴 **雙語同步**：改 `README.md` 必同步 `README_zh.md`。
-- 改任何 SKILL.md 內容 → bump version。
-
-## 待 user 拍板（別自己猜）
-1. status 欄必填嗎？值域？
-2. triggers 用 list 還是 inline array？
-3. version／status 語意規則？
-
-> 這三題定了 lint 才有一致目標；沒定前先別大改 frontmatter。
-
-## Scope 誠實
-- 上一手只深讀 prd-create / spec / adr 三顆；frontmatter 掃描涵蓋全 22。
-- 「對照 `skill_writing_patterns.md` 全 checklist 逐顆過」**尚未做**——那是接手者的主工。
+- 改任何 SKILL.md 內容 → bump version（doc 澄清走 patch、新增段落走 minor、breaking 走 major）。

--- a/adr/SKILL.md
+++ b/adr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: adr
 description: "Use when a durable technical decision was just made in conversation and should be recorded, or when user asks to write/record an ADR (開 ADR / 記個決策 / 這要不要 ADR). Runs a three-gate check FIRST and actively talks the user out of writing one when the decision doesn't qualify — then writes a lightweight (title + 1-3 sentences) ADR following the repo's own ADR conventions if any exist. Repo conventions always override this skill's defaults. NOT for requirement specs (spec / prd-create) or for rewriting history (superseded ADRs get a new ADR, never an edit)."
-version: 0.1.0
+version: 0.2.0
 status: mvp
 triggers:
   - "/adr"
@@ -89,6 +89,12 @@ ls -d adr decisions doc/adr docs/adr doc/adrs docs/adrs doc/decisions docs/decis
 5. **Lazy 建立** — 第一篇 ADR 需要時才建目錄，不預鋪結構
 6. **歷史不可改** — 取代用新 ADR，不編輯舊 ADR
 7. **不記實作細節** — 決策與理由 only
+
+## 跟其他 skill 的關係
+
+- **`spec` / `prd-create`**：那兩顆產「要做什麼、怎麼做」的需求規格；本 skill 只記「為什麼選了這條路」的單一決策。feature lifecycle 用 `spec`、stakeholder PRD 用 `prd-create`，別把整份規格塞進 ADR。
+- **`diagnose`**：debug 過程若催出一個難回頭的決策（換架構 / 換依賴），驗完可用本 skill 把「為什麼這樣修」記成 ADR；但 debug 本身走 `diagnose`。
+- 選哪顆規劃類 skill 有疑問 → 見 README 的規劃類決策框或 `workflow-router`。
 
 ## Acknowledgments
 

--- a/ctf-kit/SKILL.md
+++ b/ctf-kit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ctf-kit
 description: "Use when the user is solving an authorized CTF / lab reverse-engineering challenge focused on Windows application authentication or license-check bypass. Guides triage → static analysis → dynamic experiment planning → bypass verification, with strong evidence discipline and VM safety boundaries. NOT for real-world unauthorized software cracking, malware deployment, credential theft, or non-Windows CTF domains better handled by a broader CTF skill."
-version: 0.3.1
+version: 0.4.0
 status: mvp
 triggers:
   - "ctf"
@@ -471,6 +471,26 @@ python3 -c "print(' '.join(f'{b:02X}' for b in '你要搜的字'.encode('utf-8')
 | tshark | 命令行抓包 | 網路驗證協議分析 |
 
 ---
+
+## Anti-patterns
+
+- ❌ **猜了就動手** — 「可能是 X」還沒驗證就開始改；先設計最小驗證實驗拿到資料再決策（準則 2）
+- ❌ **靜態沒挖乾淨就跳動態** — 動態測試消耗資源、每輪要 user 配合；靜態做到沒東西可挖再一次規劃批量動態（準則 4）
+- ❌ **重試已失敗的方法** — 提方案前先對照 `failed_methods` / failure-patterns.md，相似邏輯要講清楚這次差在哪（準則 3）
+- ❌ **從加密層開刀** — Session-bound 加密直接放棄協議層；bypass 從決策層（CreateWindowEx / 錯誤訊息 backtrace）進（Phase 3）
+- ❌ **在 host 上做高風險操作** — debugger attach / 記憶體注入 / 首次跑未知行為程式一律進 VM（準則 6）
+- ❌ **目標搞錯就狂搜 flag** — 目標是 bypass 就別搜 flag、別提議用真 key；每個方案先問「達成目標了嗎」（準則 1）
+- ❌ **拿真實軟體來破** — 本 skill 只服務授權的 CTF / lab 題目；未授權的商業軟體破解不在範圍
+
+## Important rules
+
+1. **授權邊界** — 只做授權 CTF / lab；非授權破解、惡意部署、竊取憑證一律拒
+2. **先驗證再行動** — 觀察 → 最小實驗 → 資料 → 決策，不猜；區分「已驗證」與「未驗證假設」
+3. **靜態到底、動態批量** — 不消耗資源的先做滿，消耗資源的一次規劃
+4. **決策層優先於加密層** — bypass 從 if/else 判斷點進，不硬拆加密
+5. **高風險進 VM** — attach / 注入 / 未知程式首跑，全在 VM
+6. **記錄失敗** — 改了什麼、為什麼、哪些方法失敗，寫進專案 memory
+7. **卡關 15 分鐘就停** — 回查失敗模式、換層級 / 工具，不同方向硬撞
 
 ## 參考資料
 

--- a/diagnose/SKILL.md
+++ b/diagnose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: diagnose
 description: "Use when the user reports misbehaving software to investigate — a bug, crash, wrong output, flaky behavior, or '為什麼壞掉/不會動/查一下' — and the root cause is not yet established. Enforces building a red-capable reproduction command BEFORE any hypothesis is allowed, then 3-5 ranked falsifiable hypotheses before testing any single one. NOT for conceptual questions, code reading requests, or feature work. When a failing command already exists, Step 1 is pre-satisfied — still apply, jumping straight to the hypothesis discipline."
-version: 0.2.0
+version: 0.3.0
 status: mvp
 triggers:
   - "/diagnose"
@@ -104,6 +104,12 @@ H3：...
 6. **沒有正確 seam = finding**，不是硬寫測試的理由
 7. **期望值不得由實作反推** — 恆真的測試等於沒有測試
 8. **建不出 loop 要明講**，列出嘗試、要資源，不轉入猜謎模式
+
+## 跟其他 skill 的關係
+
+- **`spec`**：處理「還沒做的 feature」。症狀是既有行為壞掉（bug / crash / 錯誤輸出 / flaky）→ 本 skill；需求是新功能 → `spec`。別把 debug 包裝成開新 spec。
+- **`adr`**：debug 若催出難回頭的決策，驗完可用 `adr` 記「為什麼這樣修」；debug 流程本身留在本 skill。
+- 選哪顆有疑問 → 見 README 決策框或 `workflow-router`。
 
 ## Acknowledgments
 

--- a/job-scout/SKILL.md
+++ b/job-scout/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: job-scout
 description: "Use when the user is considering applying to, interviewing with, or accepting an offer from a company and wants due diligence on the company and optionally a specific role. Requires a company name, optionally a job title, then researches current public data, employee reviews, salary signals, product/tech quality, and red flags before giving a grounded recommendation. NOT for generic career coaching or resume editing."
-version: 1.0.1
+version: 1.1.0
 status: stable
 triggers:
   - "/job-scout"
@@ -201,6 +201,14 @@ You are a job-market due-diligence analyst. Your job is to help the user avoid b
 ```
 
 ---
+
+## Anti-patterns
+
+- ❌ **單一匿名評論當事實** — 一則負評 / 一則好評就下結論；負面訊號要跨平台交叉查證才寫進報告
+- ❌ **沒查到就腦補** — 找不到的欄位標「查無資料」，不要用產業印象或公司規模去猜營收 / 薪資
+- ❌ **舊資料當現況** — 引用沒有日期的薪資 / 財報數字；每筆都要標來源時間，過期的明講
+- ❌ **替 user 做最後決定** — 「你應該去 / 不要去」；本 skill 給風險與機會，決定權在 user
+- ❌ **道德審判紅旗** — 紅旗客觀陳述事實（低於行情多少 %、幾個月沒 commit），不加價值判斷語氣
 
 ## 注意事項
 

--- a/llm-benchmark/SKILL.md
+++ b/llm-benchmark/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llm-benchmark
 description: "Use when the user wants to test, compare, or choose local Ollama models for their machine. Checks Ollama/GPU state, recommends model sizes from available VRAM, preserves existing benchmark records, pulls only approved models, runs repeatable benchmarks, restores stopped services, and writes a markdown comparison report. NOT for hosted API model evaluation or subjective chat-quality judging without local benchmark commands."
-version: 1.0.1
+version: 1.1.0
 status: stable
 triggers:
   - "/llm-benchmark"
@@ -181,6 +181,14 @@ benchmark 完成後，讀取 `~/benchmark_results.json`，生成 `~/model_benchm
 - 回答品質排名（重點標注邏輯題正確性）
 - VRAM 使用量
 - **最終推薦**：哪個模型適合什麼情境
+
+## Anti-patterns
+
+- ❌ **沒清 VRAM 就測** — 前一個模型 / gateway 還佔著顯存，量到的 token/s 是髒的；Step 0.5 的重啟釋放是必做
+- ❌ **主觀聊感覺當 benchmark** — 「這個模型回得比較好」不算數；用可重跑的固定題目 + 數字
+- ❌ **重跑已有記錄的模型** — `benchmark_results.json` 已有的直接沿用，不浪費時間重測
+- ❌ **測完不還原服務** — 有停過的 gateway / container，全部測完要 start 回去，不留使用者服務掛掉
+- ❌ **cpu_offload 的數字混進甜蜜點** — KV cache 溢出 VRAM 被 offload 到 CPU 的 ctx，速度已失真、不列入評估
 
 ## 注意事項
 

--- a/md2pdf/SKILL.md
+++ b/md2pdf/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: md2pdf
 description: "Use when the user wants to convert one Markdown file into a publication-ready A4 PDF, especially when the source may contain Mermaid diagrams, ASCII diagrams, CJK text, tables, or pandoc/weasyprint edge cases. Works by copying the source to a _pdf.md working file, converting diagrams, escaping PDF-breaking syntax, rendering with pandoc + weasyprint, then self-checking pages. NOT for batch conversion, slide decks, or editing the original Markdown in place."
-version: 1.0.0
+version: 1.1.0
 status: stable
 triggers:
   - "/md2pdf"
@@ -141,6 +141,15 @@ Output:
 - PDF file path
 - Page count
 - Any known remaining issues (if retry limit was hit)
+
+## Anti-patterns
+
+- ❌ **Editing the original `.md`** — all changes happen on the `_pdf.md` copy; the source is never touched
+- ❌ **SVG for Mermaid** — weasyprint mis-renders SVG fonts; always render diagrams to PNG
+- ❌ **Leaving `$` unescaped outside code blocks** — pandoc pairs them into LaTeX math spans and eats table rows; escape every bare `$`
+- ❌ **Batch-converting in one call** — one file per invocation; loop by re-invoking, don't glob
+- ❌ **Retrying forever on a broken page** — cap at 3 regenerations, then stop and report the remaining issue instead of silently shipping a bad page
+- ❌ **Leaving temp files behind** — remove `mermaid-filter.lua` / `style.css`; ask before deleting `_pdf.md`
 
 ## Important Rules
 

--- a/prep-repo/SKILL.md
+++ b/prep-repo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prep-repo
 description: "Use when the user wants to prepare a local project for GitHub or public release. Runs a release-readiness sweep over README structure, bilingual docs, commit hygiene, sensitive-data exposure, broken links, markdown rendering, project layout, tests, CI, Docker, and final cleanup. Fixes issues only inside the target repo and treats secrets/history rewriting as explicit high-risk gates. NOT for publishing without user approval or for private operational runbooks that should not be open-sourced."
-version: 2.1.0
+version: 2.2.0
 status: stable
 triggers:
   - "/prep-repo"
@@ -248,6 +248,24 @@ gh repo edit OWNER/REPO --add-topic python --add-topic modbus --add-topic mcp-se
 ```
 
 - [ ] Language badge is displaying correctly (should reflect primary language, not lock files)
+
+## Anti-patterns
+
+- ❌ **未經同意就 publish / push / 改 visibility** — 這些是 user 的決定，本 skill 只做「準備」，發布動作要 user 明確要求
+- ❌ **自動重寫 git history** — 掃到歷史裡的秘密先停下、說明風險與命令；`filter-repo` / force-push 是高風險 gate，經同意才跑
+- ❌ **只掃 working tree 不掃 history** — 秘密常躺在舊 commit；Layer A（gitleaks）逐 commit 掃、Layer B（grep）補營運類 PII，兩層都要跑
+- ❌ **寬鬆 regex 一次 allowlist 一整類** — 誤報要逐條確認是 placeholder 再加 fingerprint 進 `.gitleaksignore`，不要關掉整類偵測
+- ❌ **把 private / 內部 runbook 硬改成 public 文案** — 先確認目標 visibility，不該公開的別套開源體檢
+- ❌ **README 樹與實際目錄不符** — tree 列的檔案要真的存在、重要目錄不能漏；misleading setup 跟壞掉的 docs 一樣是 blocker
+
+## Important rules
+
+1. **掃描優先，先分類再修** — 先跑完檢查、把 must-fix blocker 跟 polish 分開，再動手
+2. **秘密與改歷史是高風險 gate** — 停下說明、等 user 同意，不自動執行
+3. **雙語 README 同步** — 改 `README.md` 必同步 `README_zh.md`，語言連結用 `正體中文` / `English`
+4. **只在目標 repo 內修** — 不外溢改別的專案
+5. **進了版本庫的 token 一律作廢重簽** — 清掉不等於安全，已 clone 的人還留有舊值
+6. **post-push 檢查（§16）在推上 GitHub 後才跑**
 
 ## Execution
 

--- a/repo-scan/SKILL.md
+++ b/repo-scan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: repo-scan
 description: "Use when the user wants to evaluate a GitHub repository before installing, running, forking, or depending on it. Takes a GitHub repo URL, cleans tracking params, shallow-clones to /tmp, inspects dependency/supply-chain risk, static vulnerability patterns, issue-reported security problems, maintainer health, and produces a risk summary. NOT for reviewing the user's own PR diff or for running untrusted code."
-version: 1.0.1
+version: 1.1.0
 status: stable
 triggers:
   - "/repo-scan"
@@ -292,6 +292,14 @@ gh api repos/{owner}/{repo}/contributors --jq '.[].login' | head -10
 - **Low**：防禦縱深問題，或影響範圍小
 
 ---
+
+## Anti-patterns
+
+- ❌ **執行掃描目標** — 跑 install script、`npm install`、啟服務來「看看它做什麼」；本 skill 純靜態分析，clone 下來的 code 一律不執行
+- ❌ **star 數 / README 宣稱當安全證據** — 高星、漂亮 README 不代表安全；只看實際 code、依賴、issue、維護訊號
+- ❌ **報理論性問題湊數** — 信心不足 70% 或無實際利用場景的發現不列入；每條都要附檔案 + 行號 + 利用場景
+- ❌ **掃完不清** — clone 到 `/tmp/` 的 repo 掃完要刪，不留殘骸
+- ❌ **gh 不可用就整份放棄** — 只跳過 Phase 5（Issues），其餘照跑並註明跳過原因
 
 ## 注意事項
 

--- a/rewrite-tone/SKILL.md
+++ b/rewrite-tone/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rewrite-tone
 description: "Use when the user wants to rewrite Markdown prose into a conversational, humorous, self-deprecating engineering tone while preserving technical accuracy and document structure. Rewrites prose sections only, keeps code blocks, diagrams, tables, English summary blocks, and factual claims intact. NOT for changing requirements, adding new technical content, or editing non-Markdown artifacts."
-version: 1.0.1
+version: 1.1.0
 status: stable
 triggers:
   - "/rewrite-tone"
@@ -45,6 +45,22 @@ You are a technical editor with a conversational engineering voice. You make dry
 - Match the original file's language
 - If the file is in Traditional Chinese, write humor in Traditional Chinese
 - If bilingual (English summary + Chinese body), keep that structure
+
+## Anti-patterns
+
+- ❌ **改到事實** — 為了好笑扭曲技術描述、數字、結論；幽默只加在敘事，不動 claim
+- ❌ **動結構** — 重排章節、增刪標題層級、改 code / 表格 / 圖；本 skill 只改 prose
+- ❌ **堆 emoji 或網路梗** — 幽默來自遣詞，不是貼圖示
+- ❌ **當語病校對用** — 抓語病、地域用詞（大陸詞、翻譯腔）是 `rewrite-tw` 的事，不是本 skill
+
+## 跟 `rewrite-tw` 的分工（不重疊）
+
+| skill | 管 | 不管 |
+|---|---|---|
+| `rewrite-tone`（本 skill） | 語氣、voice、幽默感、敘事方式 | 語病、用詞地域性 |
+| `rewrite-tw` | 台灣正體中文語病、大陸詞／翻譯腔 | 語氣風格 |
+
+要「同時修語氣又修語病」→ 兩顆分開跑（先 `rewrite-tw` 定稿再 `rewrite-tone` 潤語氣，或反之），本 skill 不兼做語病校對。
 
 ## Execution
 

--- a/skill-cron/SKILL.md
+++ b/skill-cron/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-cron
 description: "Use when the user wants to register, inspect, manually run, or remove scheduled Claude skills with Telegram push notifications. Presents a menu, discovers schedulable skills with headless-prompt frontmatter, converts natural-language schedules into cron entries with conflict confirmation, writes managed config, and verifies notification delivery. NOT for one-off task execution without scheduling or for running skills that lack a headless prompt."
-version: 0.2.1
+version: 0.3.0
 status: mvp
 triggers:
   - "/skill-cron"
@@ -286,6 +286,14 @@ headless-prompt: "Run python3 ~/.claude/skills/morning-brief/scripts/fetch_news.
 排程執行的日誌存放在：`~/.claude/logs/skill-cron/`
 
 每個 job 保留最近 50 筆 log，自動清理舊的。
+
+## Anti-patterns
+
+- ❌ **模糊時間自己猜成 cron** — 描述有重疊（「平日 9:00」＋「週一 9:30」）必須問，不自行拍板哪個贏
+- ❌ **替沒有 `headless-prompt` 的 skill 硬排程** — 先要求該 skill 補 frontmatter，`-p` 模式跑不了沒 headless prompt 的 skill
+- ❌ **輸出 / log 出 Telegram token** — 只驗證設定存在與可用，token 內容不回顯、不寫進對話
+- ❌ **破壞性操作不確認** — 移除 / 覆蓋排程直接執行；每個都要先確認
+- ❌ **headless-prompt 用 `/skill` 語法** — `-p` 模式不支援 slash command，會被 silently drop；一律寫完整絕對路徑指令
 
 ## 互動規則
 

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "Use when the user wants a spec-driven development workflow for implementing a feature in the current codebase, from fuzzy idea or existing active spec through requirements, technical plan, tasks, implementation, verification, and closure report. Auto-detects project/spec state, writes persistent files under specs/, asks one grounded question at a time when requirements are ambiguous, and stops at stage gates. NOT for stakeholder PRDs (prd-create), ADO ticket breakdown (prd-breakdown), single architecture-decision records (adr), or already-frozen tasks that should simply be implemented."
-version: 1.3.1
+version: 1.4.0
 status: stable
 triggers:
   - "spec"
@@ -512,6 +512,16 @@ You are a spec-driven development lead. You turn a user feature request into per
 - **`prep-repo`**：發布前總檢查。功能已做完、要公開或推 GitHub 前 → `prep-repo`；不要用它取代 spec 的需求/實作/驗收流程。
 
 ---
+
+## Anti-patterns
+
+- ❌ **跳過 Self-Review** — 這是擋爛 spec 往下走的唯一關卡；六要素有「TBD / 待補」就是還沒想清楚，回去補
+- ❌ **自己腦補 user 意圖** — 需求模糊、六要素衝突時當場問，不猜；寧可多問一題也不要產出 user 不認同的 spec
+- ❌ **Sycophancy 式審查** — 「看起來不錯」「可以考慮加 X」；改說「X 沒定義、會在 Y 情況炸掉」的具體判斷
+- ❌ **順手改沒壞的東西** — Implement Stage 只動當前 task 需要的；不重構、不順便清 pre-existing dead code、不加超出需求的抽象
+- ❌ **恆真 / 假驗收** — AC 要可測試（不是「要好用」），驗收貼證據（file:line / 測試輸出），不用跟實作同套邏輯反推期望值
+- ❌ **同一問題硬撞** — 三次不同方法都失敗就停、跟 user 說清楚，不轉入猜謎
+- ❌ **平行開多個 spec** — 一次一個，除非 user 明確要求
 
 ## Completion Status Protocol
 


### PR DESCRIPTION
## 這輪做了什麼

第二輪 pattern lint（依 `docs/skill_writing_patterns.md`），接續 HANDOFF.md 留下的「逐顆對照 checklist」主工。Read-only 掃描先行、本 PR 落地修正。

### 補齊 anti-patterns ❌ + Important rules（8 顆）

原本缺 `❌ Anti-patterns` 段或收尾 Important rules 的：

| skill | 補了 |
|---|---|
| ctf-kit | Anti-patterns + Important rules |
| job-scout | Anti-patterns |
| llm-benchmark | Anti-patterns |
| repo-scan | Anti-patterns |
| skill-cron | Anti-patterns |
| prep-repo | Anti-patterns + Important rules |
| spec | Anti-patterns（原本只有 Anti-Sycophancy 散在文中）|
| md2pdf | Anti-patterns |

內容都從各 skill 既有的流程紀律歸納，非新增行為。

### routing 指路對稱化

- `rewrite-tone` ↔ `rewrite-tw`：補上 rewrite-tone 這側缺的分工表（原本只有 rewrite-tw 單向指）
- `adr` / `diagnose`：補「跟其他 skill 的關係」段（vs spec / prd-create / 彼此），對齊 spec / prd-create 已有的 relations 段

### HANDOFF.md 更新

- frontmatter 三題（status 必填 / triggers 格式 / version 語意）已於 #23 收，原 handoff 已 stale → 改寫為現況
- 記錄**刻意未做**的剩餘工項：大單體拆 `references/`（checklist 判準是「有進階段落才拆、緊湊單體可豁免」，逐顆判斷）、md2ppt 寫死絕對路徑

## 版本

各改動檔照紀律 bump version（新增段落走 minor）。

## 安全

無公司 / 個人 / 客戶 context 洩漏；leak grep 唯一命中是 prep-repo 既有的 `192.168.x.x` 佔位範例（leak 偵測說明的一部分，非洩漏）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)