### PR TITLE
md2pdf v1.3.0: bundled builder — measured diagram orientation, version footer, opt-in TOC

### DIFF
--- a/md2pdf/SKILL.md
+++ b/md2pdf/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: md2pdf
 description: "Use when the user wants to convert one Markdown file into a publication-ready A4 PDF, especially when the source may contain Mermaid diagrams, ASCII diagrams, CJK text, tables, or pandoc/weasyprint edge cases. Works by copying the source to a _pdf.md working file, converting diagrams, escaping PDF-breaking syntax, balancing table column widths, rendering with pandoc + weasyprint, then self-checking pages by ink coverage. Cleans up intermediates only after the user calls the version final. NOT for batch conversion, slide decks, or editing the original Markdown in place."
-version: 1.2.0
+version: 1.3.0
 status: stable
 triggers:
   - "/md2pdf"
@@ -42,13 +42,29 @@ If `{filename}_pdf.md` already exists, ask the user:
 - **Use existing**: convert `_pdf.md` directly to PDF (user may have manually tuned it)
 - **Regenerate**: copy from original and redo all conversions
 
-### Step 2: Ask CSS style preference
+### Step 2: Ask style, and ask about a table of contents
 
-Present options to the user. If they don't choose, pick the most suitable one automatically:
+**2a. CSS style.** Present options; if the user doesn't choose, pick the most suitable one automatically:
 
 - **Professional** — dark blue headers, gray alternating rows, blue accent blockquotes (good for client-facing docs)
 - **Technical** — compact, orange accent blockquotes, smaller fonts (good for dev manuals)
 - **Minimal** — black and white, no colored headers (good for printing)
+
+**2b. Table of contents — always ask, never assume.** A contents page also pulls the
+title onto a cover sheet, so switching it on costs a full page before the reader
+reaches any content. That is right for a report and absurd for a two-page memo.
+
+Ask outright. If the user has no opinion, decide by length and say which you picked:
+
+| Source length | Default | Why |
+|---------------|---------|-----|
+| Under ~6 pages of content | **No TOC** | A cover plus a contents list for a handful of sections is pure overhead |
+| Longer, or many `##` sections | **TOC** | Real page numbers make it navigable |
+
+**2c. Version footer.** If the document carries a `> Version: ...` (or `> 版本：...`)
+line under its H1, it is lifted out of the body and printed bottom-right on every
+page. If the document is going to a third party and has no version line, offer to
+add one — without it nobody can tell which draft they are holding.
 
 ### Step 3: Copy original → {filename}_pdf.md
 
@@ -67,7 +83,7 @@ Scan all code blocks (` ``` ` without language tag) and classify:
 | Anything uncertain | Unknown | Keep as-is |
 
 When converting to Mermaid:
-- Determine flow direction: prefer `LR` (horizontal) for linear flows, `TD` (vertical) for hierarchical
+- Write the direction that reads best at the source (usually `LR` for linear flows). **Do not hand-tune direction for the PDF** — Step 6 measures both orientations and picks the legible one.
 - Keep node text short (< 20 chars per line)
 - Use `<br/>` for line breaks (never `\n`)
 - Avoid markdown-triggering syntax in nodes: no `1.` prefix, no `*`, no `[]()`
@@ -80,7 +96,7 @@ When converting to Mermaid:
 - `\n` → `<br/>`
 - Remove numbered prefixes in node text (`1. `, `2. ` etc.)
 - Simplify special characters that may cause parsing errors
-- If a vertical flowchart has > 5 nodes, consider switching to `LR`
+- **Leave the flow direction alone** — Step 6 chooses it by measurement
 
 **5b. Dollar sign escaping** — pandoc interprets `$...$` as LaTeX inline math. In markdown table cells, an unescaped `$` (e.g. `NT$1`) will pair with a later `$` (e.g. `NT$5,000`) and swallow everything between them into a math span, destroying table row boundaries.
 - Escape ALL `$` signs outside of code blocks: `$` → `\$`
@@ -121,33 +137,49 @@ Re-run the script after any table edit — it is idempotent, and ratios are reco
 
 ### Step 6: Generate PDF
 
-Create temporary files:
+Use the bundled builder. It carries the CSS, the diagram pipeline, the version
+footer and the page-break rules, so none of that has to be reassembled per run:
 
-**Lua filter** (mermaid-filter.lua):
-- Intercept `mermaid` code blocks
-- Call `mmdc -o output.png -b white --scale 3`
-- Embed as PNG (never SVG — SVG has font rendering issues with weasyprint)
-
-**CSS** (based on user's style choice):
-- Body font: `"Heiti TC", "PingFang TC", "Arial Unicode MS", sans-serif`
-- Code font: `"Menlo", "Heiti TC", "Arial Unicode MS", monospace`
-- `pre code { background-color: transparent; }`
-- `img { max-width: 100%; max-height: 700px; }`
-- `white-space: pre-wrap; word-wrap: break-word;` on `pre`
-- Page: `@page { size: A4; margin: 2cm; }`
-- **`table { table-layout: fixed; }`** — required, or Step 5c's column ratios are ignored
-- **`td, th { word-wrap: break-word; overflow-wrap: break-word; }`** — keeps long cells inside their column
-- **`thead { display: table-header-group; } tr { page-break-inside: avoid; }`** — a table taller than one page should split between rows and repeat its header, not get pushed whole onto the next page leaving a mostly-blank one
-
-**pandoc command:**
 ```bash
-pandoc "{filename}_pdf.md" \
-  --lua-filter=mermaid-filter.lua \
-  --pdf-engine=weasyprint \
-  --css=style.css \
-  --no-highlight \
-  -o "{filename}.pdf"
+scripts/build_pdf.sh "{filename}_pdf.md" "{filename}.pdf" \
+  --style professional \
+  --no-toc                 # or --toc, per Step 2b
 ```
+
+Options: `--style professional|technical|minimal`, `--toc` / `--no-toc`,
+`--toc-depth N`, `--mermaid vertical|keep`.
+
+**Diagram orientation is measured, not guessed.** A horizontal chain that reads
+fine on screen is scaled to roughly a quarter inside A4's ~17cm text column and
+its labels stop being readable. But flipping blindly is also wrong: a vertical
+version can be tall enough that the height cap shrinks it right back. So the
+builder renders each `LR` diagram both ways, computes the scale the page will
+actually apply — `min(width_fit, height_fit)` — and keeps whichever orientation
+holds the larger one. Vertical costs page height, which is the cheaper resource.
+
+Measured on a six-diagram report: LR chains came out at 4.4–5.0 : 1 and were
+unreadable; going vertical grew the document from 7 to 11 pages and was still
+clearly the right trade. Pass `--mermaid keep` to opt out.
+
+What the builder handles that a bare pandoc call does not:
+
+| Behaviour | Why it matters |
+|-----------|----------------|
+| `> Version:` / `> 版本：` line → bottom-right on every page, removed from body | Otherwise nobody can tell which draft they are holding |
+| TOC off by default; title inlined when off | A named CSS page forces a break, so a cover sheet appears even with no TOC unless the title's `page:` rule is also dropped |
+| Diagrams rendered to PNG, empty alt text | SVG mis-renders fonts in weasyprint; a non-empty alt becomes a visible figure caption under every diagram |
+| `table-layout: fixed` + `thead` repeat + `tr` unbreakable | Step 5c's ratios are a no-op without `fixed`; tables taller than a page must split between rows, not jump whole to the next page |
+| Ink self-check including the **last** page | See Step 7 |
+
+⚠️ **Never add `"Apple Color Emoji"` to the CSS `font-family`, at any position.**
+It carries keycap glyphs for 0–9, and weasyprint routes every Arabic numeral in
+the document to it — they print as blank space. The text layer still contains the
+digits, so `pdftotext` looks correct and the damage is invisible until someone
+reads the paper. For coloured status markers, embed a PNG.
+
+If you need something the builder doesn't cover, fall back to assembling pandoc
+by hand — but copy the CSS out of the script rather than rewriting it, or you
+will rediscover the traps above one at a time.
 
 ### Step 7: Self-check
 
@@ -163,22 +195,38 @@ Read every page of the generated PDF. Check for:
 | A Latin word split mid-token | `PostgreS / QL` across two lines | Column narrower than its longest token → raise `TOKEN_FACTOR` in `table_widths.py` and re-run |
 | Mostly-blank page before a big table | Page under ~4% ink, next page starts with that table | Table set to `page-break-inside: avoid` but taller than one page → allow it to split, keep `tr` unbreakable, repeat `thead` |
 
-Reading 40 pages by eye is slow and misses things. Measure ink coverage first, then only look at the outliers:
+Reading 40 pages by eye is slow and misses things. `build_pdf.sh` runs this check
+automatically; the logic, if you are assembling by hand:
 
 ```bash
 pdftoppm -png -r 80 out.pdf /tmp/pg
 python3 - <<'PY'
 import glob
 from PIL import Image
-for p in sorted(glob.glob("/tmp/pg-*.png")):
+pages = sorted(glob.glob("/tmp/pg-*.png"))
+for i, p in enumerate(pages):
     im = Image.open(p).convert("L")
     ink = sum(im.histogram()[:240]) / (im.size[0] * im.size[1]) * 100
-    if ink < 4:
-        print(f"{p}: {ink:.1f}% — inspect this page")
+    last = i == len(pages) - 1
+    if (ink < 1.5 if last else ink < 4):
+        print(f"{p}: {ink:.2f}% — {'trailing orphan' if last else 'inspect this page'}")
 PY
 ```
 
-Under ~4% almost always means something got pushed to the next page. A final page below the threshold is normal (it is just the tail of the document).
+Under ~4% on a middle page almost always means a table or diagram was pushed off it.
+
+⚠️ **Do not exempt the final page from the check.** It is tempting — a tail page is
+legitimately sparse — but blanket-skipping it is exactly how a document ships with
+one stranded line on its own sheet. A genuine tail page still carries a paragraph
+or two; under ~1.5% ink means one or two lines, which is an orphan, not a tail.
+
+Fixing an orphan is not "delete a sentence until it fits". The reliable move is to
+**fold the closing line into the block above it** — into the last table row, or
+into the preceding paragraph. Trimming prose is unreliable: shortening a line that
+still wraps to the same number of rendered lines frees nothing, and the boundary
+does not move. Measure instead of guessing: if the free space at the bottom of the
+previous page is smaller than one line height plus the paragraph's top margin, no
+amount of rewording that keeps the paragraph separate will pull it up.
 
 If issues found: fix `_pdf.md`, regenerate. **Maximum 3 retries**, then stop and report remaining issues to user.
 
@@ -218,6 +266,12 @@ Output:
 - ❌ **Leaving `|---|---|---|` on every table** — equal widths make a `#` column as wide as a prose column and waste a large share of each page; run `scripts/table_widths.py`
 - ❌ **Setting column ratios but forgetting `table-layout: fixed`** (or vice versa) — the two halves only work together; one alone is a silent no-op
 - ❌ **Reading `-f gfm` output and wondering why widths are ignored** — the gfm reader drops separator proportions; use pandoc's default markdown reader
+- ❌ **Hand-picking diagram direction for the PDF** — `LR` looks right in the source and prints too small; blind flipping to `TD` can be worse. Let the builder render both and measure
+- ❌ **Adding `"Apple Color Emoji"` to the font stack** — every digit in the document silently prints blank while `pdftotext` still shows them
+- ❌ **Non-empty alt text on rendered diagrams** — pandoc promotes it to a figure caption, printing the alt word under every diagram
+- ❌ **Turning the TOC on by default** — it drags the title onto a cover sheet; two pages of overhead in front of a short memo. Ask
+- ❌ **Exempting the last page from the ink check** — that is how a one-line orphan page ships
+- ❌ **Trimming prose to kill an orphan page** — shortening text that still wraps to the same line count frees nothing; fold the line into the block above instead
 - ❌ **Cleaning up before the user signs off** — deleting `_pdf.md` and the CSS mid-iteration means rebuilding all manual tuning on the next round
 - ❌ **Overwriting a PDF the user asked to keep** — give the new render a version suffix instead
 - ❌ **Leaving temp files behind after sign-off** — once the version is final, remove `_pdf.md`, `mermaid-filter.lua`, `style.css` and diagram PNGs without asking again
@@ -231,4 +285,8 @@ Output:
 - **Fixed A4 page size** — no other options
 - **One file at a time** — user can invoke multiple times for batch
 - **Table widths need markdown ratios AND `table-layout: fixed`** — neither half works alone
+- **Ask before adding a TOC** — it costs a cover sheet plus a contents page
+- **Lift the version line into a per-page footer** — a third party must be able to tell which draft they hold
+- **Let the builder measure diagram orientation** — never hand-tune `LR`/`TD` for print
+- **Check the last page too** — under ~1.5% ink is an orphan, not a tail
 - **Clean up only after the user calls the version final** — then delete the intermediates outright, no second confirmation

--- a/md2pdf/scripts/build_pdf.sh
+++ b/md2pdf/scripts/build_pdf.sh
@@ -251,7 +251,7 @@ pandoc "$WORK/doc.md" \
   --syntax-highlighting=none \
   -o "$OUT"
 
-echo "wrote: $PWD/$OUT"
+case "$OUT" in /*) echo "wrote: $OUT" ;; *) echo "wrote: $PWD/$OUT" ;; esac
 
 # ---------------------------------------------------------------- self-check
 # Two different failures, two different thresholds:

--- a/md2pdf/scripts/build_pdf.sh
+++ b/md2pdf/scripts/build_pdf.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# build_pdf.sh — Markdown -> A4 PDF (pandoc + weasyprint), with the layout
+# decisions that are painful to rediscover every time baked in.
+#
+#   ./build_pdf.sh SOURCE.md [OUTPUT.pdf] [options]
+#
+# Options
+#   --style professional|technical|minimal   default: professional
+#   --toc / --no-toc                         default: --no-toc
+#   --toc-depth N                            default: 2
+#   --mermaid vertical|keep                  default: vertical (see below)
+#
+# Requires: pandoc, mmdc (@mermaid-js/mermaid-cli), weasyprint.
+# Optional: pdftoppm + Pillow, for the per-page ink self-check.
+#
+# What this handles that a bare pandoc call does not
+# --------------------------------------------------
+# 1. VERSION FOOTER. A `> Version: x` / `> 版本：x` line directly under the H1 is
+#    lifted out of the body and printed bottom-right on every page. Without it,
+#    nobody can tell which draft they are holding. No version line -> no footer.
+# 2. TOC IS OPT-IN. A cover page plus a contents list for a 2-page document is
+#    pure overhead. Off by default; turn it on for long documents.
+# 3. WIDE MERMAID -> VERTICAL. A `flowchart LR` chain is fine on screen but gets
+#    scaled down to unreadable when squeezed into A4's ~17cm text column. Long
+#    horizontal chains are flipped to TD for the PDF only; the source keeps LR.
+# 4. TABLES SPLIT, ROWS DO NOT. A table taller than the page must break between
+#    rows with the header repeated, or it gets pushed whole onto the next page
+#    and leaves most of one blank.
+#
+# The original file is never modified; all rewriting happens on a temp copy.
+
+set -euo pipefail
+
+SRC_IN=""; OUT=""; STYLE="professional"; WANT_TOC=0; TOC_DEPTH=2; MERMAID="vertical"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --style)     STYLE="$2"; shift 2 ;;
+    --toc)       WANT_TOC=1; shift ;;
+    --no-toc)    WANT_TOC=0; shift ;;
+    --toc-depth) TOC_DEPTH="$2"; shift 2 ;;
+    --mermaid)   MERMAID="$2"; shift 2 ;;
+    -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
+    -*)          echo "unknown option: $1" >&2; exit 2 ;;
+    *)           if [ -z "$SRC_IN" ]; then SRC_IN="$1"; else OUT="$1"; fi; shift ;;
+  esac
+done
+
+[ -n "$SRC_IN" ] || { echo "usage: build_pdf.sh SOURCE.md [OUTPUT.pdf] [options]" >&2; exit 2; }
+[ -f "$SRC_IN" ] || { echo "source not found: $SRC_IN" >&2; exit 1; }
+
+for t in pandoc mmdc weasyprint; do
+  command -v "$t" >/dev/null || { echo "missing: $t" >&2; exit 1; }
+done
+
+# Work from the source file's directory so relative <img src="img/..."> still resolve.
+SRC_ABS="$(cd "$(dirname "$SRC_IN")" && pwd)/$(basename "$SRC_IN")"
+cd "$(dirname "$SRC_ABS")"
+SRC="$(basename "$SRC_ABS")"
+OUT="${OUT:-$(basename "$SRC" .md).pdf}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------- preprocess
+python3 - "$SRC" "$WORK/doc.md" "$MERMAID" "$WORK" <<'PY'
+import re, struct, subprocess, sys
+
+src, dst, mermaid_mode, work = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+s = open(src, encoding="utf-8").read()
+
+# --- Mermaid: render, and pick the orientation that stays legible ----------
+# A horizontal chain is fine on screen and too small on paper: A4's text column
+# is ~17cm, so a 5:1 diagram is scaled to about a quarter and its labels stop
+# being readable. Which orientation wins is not guessable from node count -- a
+# vertical version can be so tall that the height cap shrinks it right back.
+#
+# So render both and measure. The objective is the scale factor the page will
+# actually apply, min(width_fit, height_fit); whichever orientation keeps the
+# larger one keeps the bigger text. Vertical costs page height, which is the
+# cheaper resource. `--mermaid keep` opts out entirely.
+PAGE_W_PX = 643      # 17cm text column at 96dpi
+PAGE_H_PX = 640      # CSS img max-height
+flipped = rendered = 0
+
+def png_size(path):
+    with open(path, "rb") as f:
+        return struct.unpack(">II", f.read(26)[16:24])
+
+def render(body, tag):
+    mmd, png = f"{work}/{tag}.mmd", f"{work}/{tag}.png"
+    open(mmd, "w", encoding="utf-8").write(body)
+    r = subprocess.run(["mmdc", "-i", mmd, "-o", png, "-b", "white", "--scale", "3"],
+                       capture_output=True)
+    if r.returncode != 0:
+        return None
+    try:
+        return png, png_size(png)
+    except Exception:
+        return None
+
+def fit(size):
+    w, h = size
+    return min(PAGE_W_PX / w, PAGE_H_PX / h)
+
+def handle(m):
+    global flipped, rendered
+    body = m.group(1)
+    rendered += 1
+    tag = f"d{rendered}"
+    base = render(body, tag)
+    if base is None:
+        return m.group(0)          # let it through as a code block rather than lose it
+    png, size = base
+    horizontal = re.match(r"^\s*(flowchart|graph)\s+LR\b", body)
+    if mermaid_mode == "vertical" and horizontal:
+        alt_body = re.sub(r"^(\s*)(flowchart|graph)\s+LR\b", r"\1\2 TD", body, count=1, flags=re.M)
+        alt = render(alt_body, tag + "v")
+        if alt and fit(alt[1]) > fit(size):
+            png = alt[0]
+            flipped += 1
+    # Alt text must stay empty: pandoc promotes a non-empty alt into a figure
+    # caption, so every diagram would print the word "diagram" underneath it.
+    return f"![]({png})"
+
+s, total = re.subn(r"```mermaid\n(.*?)```", handle, s, flags=re.S)
+
+# --- H1 -> pandoc metadata title ------------------------------------------
+# Must be removed from the body, not hidden with {.unlisted}: the H1 is the TOC's
+# only top-level entry and everything else nests under it, so marking it unlisted
+# deletes the entire tree and the contents page comes out empty.
+m = re.search(r"^# (.+)$", s, flags=re.M)
+title = m.group(1).strip() if m else ""
+if m:
+    s = s[:m.start()] + s[m.end():].lstrip("\n")
+
+# --- Version line -> per-page footer --------------------------------------
+mv = re.search(r"^> *(?:版本|Version)[：:] *(.+)$", s, flags=re.M)
+version = mv.group(1).strip() if mv else ""
+if mv:
+    s = s[:mv.start()] + s[mv.end():].lstrip("\n")
+
+open(dst, "w", encoding="utf-8").write(s)
+open(dst + ".title", "w", encoding="utf-8").write(title)
+open(dst + ".version", "w", encoding="utf-8").write(version)
+
+print(f"title: {title or '(none)'}")
+print(f"version footer: {version or '(none — no `> Version:` line found)'}")
+print(f"mermaid: {total} diagram(s), {flipped} turned vertical for legibility")
+PY
+
+# -------------------------------------------------------------------- styles
+case "$STYLE" in
+  professional) ACCENT="#1a3a5c"; ACCENT2="#2c5480"; RULE="#c8d4e0"; ZEBRA="#f4f7fa"; BODY_PT="10.5pt"; TBL_PT="9.5pt" ;;
+  technical)    ACCENT="#8a4b08"; ACCENT2="#a9631a"; RULE="#e0d2c0"; ZEBRA="#faf6f1"; BODY_PT="10pt";   TBL_PT="9pt" ;;
+  minimal)      ACCENT="#000000"; ACCENT2="#333333"; RULE="#cccccc"; ZEBRA="#f5f5f5"; BODY_PT="10.5pt"; TBL_PT="9.5pt" ;;
+  *) echo "unknown --style: $STYLE (professional|technical|minimal)" >&2; exit 2 ;;
+esac
+if [ "$STYLE" = "minimal" ]; then TH_BG="#ffffff"; TH_FG="#000000"; else TH_BG="$ACCENT"; TH_FG="#ffffff"; fi
+
+cat > "$WORK/style.css" <<CSS
+@page { size: A4; margin: 2cm; @bottom-center { content: counter(page); font-size: 9pt; color: #888; } }
+__VERSION_FOOTER__
+
+/* NEVER add "Apple Color Emoji" to this font-family, at any position. It carries
+   keycap glyphs for 0-9, and weasyprint will route every Arabic numeral in the
+   document to it -- they then print as blank space. The text layer still contains
+   the digits, so the damage is invisible until someone looks at the paper.
+   For coloured status markers, embed a PNG instead of relying on emoji glyphs. */
+body { font-family: "Heiti TC","PingFang TC","Arial Unicode MS",sans-serif; font-size: $BODY_PT; line-height: 1.65; color: #222; }
+h1 { color: $ACCENT; font-size: 20pt; border-bottom: 3px solid $ACCENT; padding-bottom: 8px; }
+h2 { color: $ACCENT; font-size: 15pt; margin-top: 1.6em; border-bottom: 1px solid $RULE; padding-bottom: 4px; page-break-after: avoid; }
+h3 { color: $ACCENT2; font-size: 12.5pt; margin-top: 1.2em; page-break-after: avoid; }
+h4 { color: $ACCENT2; font-size: 11pt; page-break-after: avoid; }
+
+/* table-layout: fixed is what makes the separator-row dash ratios (which pandoc
+   emits as <col style="width:N%">) actually bind. Ratios alone are a silent
+   no-op; run scripts/table_widths.py to compute them from cell contents. */
+table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: $TBL_PT; page-break-inside: auto; table-layout: fixed; }
+td, th { word-wrap: break-word; overflow-wrap: break-word; }
+thead { display: table-header-group; }
+tr { page-break-inside: avoid; }
+th { background-color: $TH_BG; color: $TH_FG; padding: 7px 9px; text-align: left; font-weight: 600; border-bottom: 2px solid $RULE; }
+td { padding: 6px 9px; border-bottom: 1px solid $RULE; vertical-align: top; }
+tr:nth-child(even) td { background-color: $ZEBRA; }
+
+blockquote { border-left: 4px solid $ACCENT2; background: $ZEBRA; margin: 1em 0; padding: 0.6em 1em; color: #33475b; }
+code { font-family: "Menlo","Heiti TC","Arial Unicode MS",monospace; font-size: 9pt; background: #eef1f5; padding: 1px 4px; border-radius: 3px; }
+pre { white-space: pre-wrap; word-wrap: break-word; background: #f6f8fa; padding: 10px; border-radius: 4px; }
+pre code { background-color: transparent; padding: 0; }
+img { max-width: 100%; max-height: 640px; display: block; margin: 1em auto; }
+/* Tall portrait diagrams need more headroom than the default; A4's text area is
+   25.7cm high, so leave room for the heading that precedes it.
+   Use a class, not img[src*="..."]: --pdf-engine base64-inlines images, so the
+   src becomes data:image/png;... and attribute selectors never match. */
+img.tall { max-height: 23cm; }
+a { color: $ACCENT2; text-decoration: none; }
+ul, ol { padding-left: 1.6em; }
+li { margin: 0.25em 0; }
+
+/* Contents page. weasyprint supports target-counter() for real page numbers and
+   leader('.') for the dot fill. pandoc --toc emits <nav id="TOC">. */
+h1.title { color: $ACCENT; font-size: 20pt; font-weight: 700; border-bottom: 3px solid $ACCENT; padding-bottom: 8px; margin-bottom: 1.4em; }
+__TOC_PAGE__
+nav#TOC::before {
+  content: "__TOC_LABEL__";
+  display: block; color: $ACCENT; font-size: 15pt; font-weight: 700;
+  border-bottom: 1px solid $RULE; padding-bottom: 4px; margin-top: 1.6em; margin-bottom: 1em;
+}
+nav#TOC ul { list-style: none; padding-left: 0; margin: 0; }
+nav#TOC > ul > li { margin-top: .5em; font-weight: 600; }
+nav#TOC ul ul { padding-left: 1.4em; margin-top: .2em; }
+nav#TOC ul ul li { font-weight: 400; font-size: 10pt; }
+nav#TOC a { color: #222; text-decoration: none; }
+nav#TOC a::after { content: leader('.') target-counter(attr(href), page); color: #8a97a5; font-weight: 400; }
+@page toc { @bottom-center { content: none; } }
+CSS
+
+VER="$(cat "$WORK/doc.md.version" 2>/dev/null || true)"
+TOC_LABEL="${TOC_LABEL:-Contents}"
+
+python3 - "$WORK/style.css" "$VER" "$WANT_TOC" "$TOC_LABEL" <<'PY'
+import sys
+path, version, want_toc, label = sys.argv[1], sys.argv[2], sys.argv[3] == "1", sys.argv[4]
+css = open(path, encoding="utf-8").read()
+
+css = css.replace("__VERSION_FOOTER__",
+    '@page { @bottom-right { content: "%s"; font-size: 8pt; color: #999; } }' % version.replace('"', "'")
+    if version else "")
+
+# A named page forces a break, so the title block and the TOC must share ONE named
+# page or they each take a sheet. With no TOC, the title must NOT be on a named
+# page at all, or it still gets a sheet to itself in front of a 2-page document.
+css = css.replace("__TOC_PAGE__",
+    "header#title-block-header { page: toc; }\nnav#TOC { page: toc; page-break-after: always; }"
+    if want_toc else "header#title-block-header { margin-top: 0; }")
+css = css.replace("__TOC_LABEL__", label)
+open(path, "w", encoding="utf-8").write(css)
+PY
+
+# -------------------------------------------------------------------- render
+# Note the `+` expansion: under `set -u`, bash 3.2 (still the macOS default)
+# treats "${arr[@]}" on an empty array as an unbound variable and aborts.
+TOC_ARGS=()
+[ "$WANT_TOC" = "1" ] && TOC_ARGS=(--toc --toc-depth="$TOC_DEPTH")
+
+pandoc "$WORK/doc.md" \
+  ${TOC_ARGS[@]+"${TOC_ARGS[@]}"} \
+  --metadata title="$(cat "$WORK/doc.md.title")" \
+  --pdf-engine=weasyprint \
+  --css="$WORK/style.css" \
+  --resource-path=".:$PWD:$WORK" \
+  --syntax-highlighting=none \
+  -o "$OUT"
+
+echo "wrote: $PWD/$OUT"
+
+# ---------------------------------------------------------------- self-check
+# Two different failures, two different thresholds:
+#   - a middle page under ~4% ink means a table or diagram was pushed off it
+#   - a LAST page holding one or two lines is a trailing orphan. Do NOT exempt
+#     the final page from checking: a real tail page is still fairly full, and
+#     blanket-skipping it is exactly how a one-line page ships unnoticed.
+if command -v pdftoppm >/dev/null; then
+  pdftoppm -png -r 80 "$OUT" "$WORK/pg"
+  python3 - "$WORK" "$WANT_TOC" <<'PY'
+import glob, sys
+try:
+    from PIL import Image
+except ImportError:
+    print("(Pillow not installed — skipping ink self-check)"); raise SystemExit
+work, want_toc = sys.argv[1], sys.argv[2] == "1"
+pages = sorted(glob.glob(work + "/pg-*.png"))
+def ink(p):
+    im = Image.open(p).convert("L")
+    return sum(im.histogram()[:240]) / (im.size[0] * im.size[1]) * 100
+thin, orphan = [], None
+for i, p in enumerate(pages):
+    if i == 0 and want_toc:      # cover + contents is legitimately sparse
+        continue
+    v = ink(p)
+    if i == len(pages) - 1:
+        if v < 1.5 and len(pages) > 1:
+            orphan = v
+    elif v < 4:
+        thin.append((i + 1, v))
+print(f"{len(pages)} page(s)")
+if thin:
+    print("WARNING thin pages (something was pushed off):",
+          ", ".join(f"p{n} {v:.1f}%" for n, v in thin))
+if orphan is not None:
+    print(f"WARNING last page is a trailing orphan ({orphan:.2f}% ink) — "
+          "shorten the text above it, or fold the closing line into the "
+          "preceding block, so the document ends one page earlier")
+if not thin and orphan is None:
+    print("ink check passed — no thin or orphan pages")
+PY
+fi


### PR DESCRIPTION
## What

Adds `md2pdf/scripts/build_pdf.sh` and folds four recurring hand-tuning steps into the skill so they stop being rediscovered per document.

## Why

Each of these came out of repeated manual fixing on real documents:

| Change | Problem it removes |
|---|---|
| **Measured diagram orientation** | `LR` reads fine on screen and prints at ~1/4 scale in A4's 17cm column — labels become unreadable. Blind flipping to `TD` is also wrong: a tall diagram hits the height cap and shrinks back. The builder now renders both and keeps whichever gives the larger `min(width_fit, height_fit)`. Measured on a 6-diagram report: LR chains were 4.4–5.0 : 1; going vertical grew it 7 → 11 pages and was still clearly right. |
| **Version footer** | A `> Version:` / `> 版本：` line becomes a bottom-right footer on every page. Without it a reader cannot tell which draft they hold. |
| **Opt-in TOC** | A TOC also pulls the title onto a cover sheet — two pages of overhead in front of a short memo. Now asked about, with a length-based default. |
| **Last-page ink check** | The previous text called a sparse final page "normal". That is exactly how a document ships with one stranded line on its own sheet. Final page now checked at a tighter threshold and reported as an orphan. |

Also recorded: **never put `"Apple Color Emoji"` in the CSS font stack** — weasyprint routes every Arabic numeral to its keycap glyphs and they print blank, while `pdftotext` still shows the digits, so the damage is invisible until someone reads the paper.

Orphan pages are fixed by **folding the closing line into the block above**, not by trimming prose — shortening text that still wraps to the same rendered line count frees nothing and the page boundary does not move.

## Notes

- `scripts/table_widths.py` unchanged; the builder relies on it and the SKILL text already covers it.
- Manual pandoc assembly still documented as a fallback.
- `--mermaid keep` opts out of orientation changes.

## Test

Exercised on two real documents (one table-only, one with six flowcharts):

- `--no-toc` / `--toc` / `--style minimal` — all render, page counts as expected
- orphan detection — correctly flags a 0.37% trailing page with an actionable message
- orientation — 6/6 diagrams flipped by measurement; verified by eye that vertical is materially more readable
- empty alt text — confirms no stray "diagram" caption under each figure
- `bash -n` clean; runs on macOS bash 3.2 (empty-array expansion guarded under `set -u`)