### PR TITLE
gpt-image-gen 0.5.1 — 描述欄位別再宣稱用 $imagegen token

### DIFF
--- a/gpt-image-gen/SKILL.md
+++ b/gpt-image-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gpt-image-gen
-description: "Use when the user asks to generate OR edit an image via GPT/Codex (e.g. 「叫 gpt 生圖」「幫我用 gpt 生圖」「gpt 畫一個 X」「幫我去背」「把這張圖的背景去掉」). The skill drafts a Chinese + English prompt pair, iterates with the user until they explicitly approve, then dispatches Codex CLI ($imagegen skill, codex built-in image_gen) in the background, monitors progress, collects the result into the current working directory, and writes a sidecar prompt log. Three modes: text-to-image; img2img (drop a reference image on disk and it runs Codex `-i` to lock a face/character across scenes); and EDIT mode (background removal, targeted local changes) where the prompt is written as 'keep every pixel, change only X' and the result is verified for size, alpha and pixel fidelity before delivery."
-version: 0.5.0
+description: "Use when the user asks to generate OR edit an image via GPT/Codex (e.g. 「叫 gpt 生圖」「幫我用 gpt 生圖」「gpt 畫一個 X」「幫我去背」「把這張圖的背景去掉」). The skill drafts a Chinese + English prompt pair, iterates with the user until they explicitly approve, then dispatches Codex CLI (natural-language instruction to codex's built-in image_gen) in the background, monitors progress, collects the result into the current working directory, and writes a sidecar prompt log. Three modes: text-to-image; img2img (drop a reference image on disk and it runs Codex `-i` to lock a face/character across scenes); and EDIT mode (background removal, targeted local changes) where the prompt is written as 'keep every pixel, change only X' and the result is verified for size, alpha and pixel fidelity before delivery."
+version: 0.5.1
 status: mvp
 triggers:
   - "叫 gpt 生圖"


### PR DESCRIPTION
## 問題

frontmatter 的 `description` 寫著：

> dispatches Codex CLI (**`$imagegen` skill**, codex built-in image_gen)

但同一份文件的內文明講相反的事：

> 用**自然語指示**叫 codex 走內建 image_gen，**不靠 `$imagegen` token** —— 自然語更穩，也免去 `$` 被 shell 展開的坑

反例清單也列著：

> ❌ 用 `$imagegen` token 卻沒 escape `\$imagegen`（shell 展開成空）

**描述與內文互相矛盾。**

## 影響

小。`description` 的作用是讓模型判斷「要不要啟動這個 skill」，括號裡的實作細節不參與那個判斷。

壞處是：只讀描述沒讀內文的人會照著去用那個 token，然後撞上「`$` 展開成空字串 → 指令等於什麼都沒說」的坑。（寫這個 PR 的過程中 grep 那句話時就實際踩了一次。）

## 改動

一行描述 ＋ 版本號。**行為零變動。**

`0.5.0` → `0.5.1`（patch：依 `docs/skill_writing_patterns.md` 的 semver 規則，「patch ＝ bug fix / 文案修」）